### PR TITLE
Silver IQS compliance + dataclass refactor Phase 1

### DIFF
--- a/custom_components/metservice_weather/config_flow.py
+++ b/custom_components/metservice_weather/config_flow.py
@@ -87,6 +87,42 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.user_info = dict(self._reconfig_entry.data)
         return await self.async_step_setup()
 
+    async def async_step_reauth(self, entry_data: dict):
+        """Handle reauth initiated by ConfigEntryAuthFailed."""
+        self._reauth_entry = self._get_reauth_entry()
+        if self._reauth_entry.data.get(CONF_API) != "mobile":
+            return self.async_abort(reason="not_applicable")
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Show form to collect a replacement mobile API key."""
+        errors = {}
+        if user_input is not None:
+            api_key = user_input.get(CONF_MOBILE_API_KEY, "").strip()
+            if not api_key:
+                errors[CONF_MOBILE_API_KEY] = "api_key_required"
+            else:
+                try:
+                    session = async_create_clientsession(self.hass)
+                    with async_timeout.timeout(10):
+                        response = await session.get(
+                            "https://api.metservice.com/mobile/nz/weatherData/-43.123/172.123",
+                            headers={**_MOBILE_HEADERS, "apiKey": api_key},
+                        )
+                    if response.status == HTTPStatus.OK:
+                        return self.async_update_reload_and_abort(
+                            self._reauth_entry,
+                            data={**self._reauth_entry.data, CONF_MOBILE_API_KEY: api_key},
+                        )
+                    errors[CONF_MOBILE_API_KEY] = "invalid_api_key"
+                except Exception:
+                    errors["base"] = "cannot_connect"
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_MOBILE_API_KEY): str}),
+            errors=errors,
+        )
+
     # ------------------------------------------------------------------ #
     # Step 1 of 2: setup                                                   #
     # ------------------------------------------------------------------ #

--- a/custom_components/metservice_weather/coordinator.py
+++ b/custom_components/metservice_weather/coordinator.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from http import HTTPStatus
 import logging
 import re
 from typing import Any
 
 import aiohttp
 import async_timeout
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.util import dt as dt_util
 
 from homeassistant.core import HomeAssistant
@@ -160,6 +162,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
                 url = f"{self._api_url}/{self._latitude}/{self._longitude}"
                 _LOGGER.info("Fetching MetService mobile data from %s", url)
                 response = await self._session.get(url, headers=headers)
+                if response.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                    raise ConfigEntryAuthFailed(
+                        "Mobile API key rejected (HTTP %s)" % response.status
+                    )
                 result_current = await response.json(content_type=None)
                 if result_current is None:
                     raise ValueError("No current weather data received.")
@@ -191,14 +197,13 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
                 RESULTS_FORECAST_DAILY: result_daily,
             }
 
+        except ConfigEntryAuthFailed:
+            raise
         except ValueError as err:
-            _LOGGER.error("Data validation error: %s", err)
             raise UpdateFailed(f"Data validation error: {err}") from err
         except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.error("Error fetching MetService data: %s", repr(err))
             raise UpdateFailed(f"Error fetching MetService data: {err}") from err
         except Exception as err:
-            _LOGGER.error("Unexpected error fetching MetService data: %s", repr(err))
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
     async def get_public_weather(self):
@@ -316,13 +321,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             }
 
         except ValueError as err:
-            _LOGGER.error("Data validation error: %s", err)
             raise UpdateFailed(f"Data validation error: {err}") from err
         except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.error("Error fetching MetService data: %s", repr(err))
             raise UpdateFailed(f"Error fetching MetService data: {err}") from err
         except Exception as err:
-            _LOGGER.error("Unexpected error fetching MetService data: %s", repr(err))
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
     async def get_tides(self):
@@ -556,8 +558,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             result = self.get_from_dict(self.data[RESULTS_CURRENT], keys)
             return result
         except Exception as e:
-            _LOGGER.error("Error retrieving public sensor '%s': %s", field, e)
-            return None  # Return a dummy value if an error occurs
+            _LOGGER.debug("Error retrieving public sensor '%s': %s", field, e)
+            return None
 
     def get_current_mobile(self, field):
         """Get a specific key from the MetService returned data."""
@@ -566,8 +568,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             result = self.get_from_dict(self.data[RESULTS_CURRENT], keys)
             return result
         except Exception as e:
-            _LOGGER.error("Error retrieving mobile sensor '%s': %s", field, e)
-            return None  # Return a dummy value if an error occurs
+            _LOGGER.debug("Error retrieving mobile sensor '%s': %s", field, e)
+            return None
 
     def get_forecast_daily_public(self, field, day):
         """Get a specific key from the MetService returned data."""
@@ -580,7 +582,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             result = self.get_from_dict(this_day, keys)
             return result
         except Exception as e:
-            _LOGGER.error("Error retrieving public forecast daily sensor '%s' for day %s: %s", field, day, e)
+            _LOGGER.debug("Error retrieving public forecast daily sensor '%s' for day %s: %s", field, day, e)
             return None
 
     def get_forecast_daily_mobile(self, field, day):
@@ -594,7 +596,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             result = self.get_from_dict(this_day, keys)
             return result
         except Exception as e:
-            _LOGGER.error("Error retrieving mobile forecast daily sensor '%s' for day %s: %s", field, day, e)
+            _LOGGER.debug("Error retrieving mobile forecast daily sensor '%s' for day %s: %s", field, day, e)
             return None
 
     @staticmethod
@@ -621,7 +623,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
                     async with async_timeout.timeout(10):
                         response = await self._session.get(full_url, headers=self._PUBLIC_HEADERS)
                         if response.status != 200:
-                            _LOGGER.error("Error fetching %s: HTTP %s", full_url, response.status)
+                            _LOGGER.warning("Error fetching %s: HTTP %s", full_url, response.status)
                             if parent is not None and key is not None:
                                 parent[key] = None
                             return
@@ -632,7 +634,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
                     # structural traversal, so the guard catches URL expansion cycles.
                     await self.expand_data_urls(result, parent=parent, key=key, _depth=_depth + 1)
                 except Exception as e:
-                    _LOGGER.error("Error fetching dataUrl %s: %s", full_url, e)
+                    _LOGGER.warning("Error fetching dataUrl %s: %s", full_url, e)
                     if parent is not None and key is not None:
                         parent[key] = None
             else:

--- a/custom_components/metservice_weather/coordinator_types.py
+++ b/custom_components/metservice_weather/coordinator_types.py
@@ -1,0 +1,299 @@
+"""Typed data models for the MetService coordinator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _get(data: Any, *path: str) -> Any:
+    """Exact-path traversal — no depth-first search.
+
+    Numeric path parts are treated as list indices.
+    """
+    for part in path:
+        if data is None:
+            return None
+        if isinstance(data, list):
+            try:
+                data = data[int(part)]
+            except (IndexError, ValueError):
+                return None
+        elif isinstance(data, dict):
+            data = data.get(part)
+        else:
+            return None
+    return data
+
+
+def _safe_float(val: Any) -> float | None:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(val: Any) -> int | None:
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_module(modules: list, key: str) -> dict:
+    """Return the first module dict that contains `key`, or {}."""
+    for m in modules:
+        if isinstance(m, dict) and key in m:
+            return m
+    return {}
+
+
+@dataclass
+class HourlyEntry:
+    datetime: str
+    temperature: float | None
+    rainfall: float | None
+    wind_speed: float | None
+    wind_direction: str | None
+
+
+@dataclass
+class DailyEntry:
+    datetime: str | None
+    condition: str | None
+    temp_high: str | None
+    temp_low: str | None
+    description: str | None
+    rainfall_low: float | None
+    rainfall_high: float | None
+
+
+@dataclass
+class MetServicePublicData:
+    # Current observations
+    temperature: float | None
+    feels_like: float | None
+    temp_today_high: float | None
+    temp_today_low: float | None
+    humidity: int | None
+    pressure: float | None
+    pressure_trend: str | None
+    wind_speed: float | None
+    wind_gust: float | None
+    wind_direction: str | None
+    wind_strength: str | None
+    rainfall: float | None
+    condition: str | None
+    forecast_text: str | None
+    issued_at: str | None
+    uv_index: str | None
+    location_name: str | None
+
+    # Sub-day breakdown
+    breakdown_morning: str | None
+    breakdown_afternoon: str | None
+    breakdown_evening: str | None
+    breakdown_overnight: str | None
+
+    # Sun / moon
+    sunrise: str | None
+    sunset: str | None
+    moonrise: str | None
+    moonset: str | None
+    moon_phase: str | None
+    moon_phase_date: str | None
+
+    # Fire weather
+    fire_danger: str | None
+    fire_season: str | None
+
+    # Pollen (injected)
+    pollen_level: str | None
+    pollen_type: str | None
+
+    # Derived / injected
+    weather_warnings: str
+    tomorrow_condition: str | None
+    tomorrow_temp_high: str | None
+    tomorrow_temp_low: str | None
+    tomorrow_description: str | None
+    drying_morning: str | None
+    drying_afternoon: str | None
+    drying_next_good_day: str | None
+
+    # Hourly forecast
+    hourly_entries: list[HourlyEntry]
+    hourly_obs: int | None
+    hourly_skip: int | None
+
+    # Daily forecast
+    daily_entries: list[DailyEntry]
+
+    # Optional marine (None / empty when not configured)
+    tides: Any | None = None
+    boating_forecast: str | None = None
+    boating_status: str | None = None
+    boating_table: Any | None = None
+    surf_conditions: str | None = None
+    surf_rating: str | None = None
+    surf_wave_height: str | None = None
+    surf_set_face: str | None = None
+    surf_swell_direction: str | None = None
+    surf_swell_height: str | None = None
+    surf_wind_direction: str | None = None
+    surf_wind_speed: str | None = None
+    surf_wind_gust: str | None = None
+    surf_period: str | None = None
+
+
+def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
+    """Build a MetServicePublicData from raw coordinator dicts.
+
+    Uses exact-path traversal (_get) and explicit section extraction —
+    no DFS.  All injected fields (weather_warnings, pollen, tomorrow_*,
+    drying_*) are already present at the root of `current` when this is
+    called.
+    """
+    # ------------------------------------------------------------------
+    # Extract key sections from the nested layout structure
+    # ------------------------------------------------------------------
+
+    # Observations: layout.primary.slots.left-major.modules → module with "observations"
+    left_major = _get(current, "layout", "primary", "slots", "left-major", "modules") or []
+    obs = _find_module(left_major, "observations").get("observations", {})
+
+    # Days / breakdown / fire: layout.primary.slots.main.modules → module with "days"
+    main_mods = _get(current, "layout", "primary", "slots", "main", "modules") or []
+    days = _find_module(main_mods, "days").get("days", [])
+    day0 = days[0] if days else {}
+    breakdown0 = day0.get("breakdown", {}) if isinstance(day0, dict) else {}
+
+    # Hourly graph: layout.primary.slots.main.modules → module with "graph"
+    graph = _find_module(main_mods, "graph").get("graph", {})
+    graph_series = graph.get("series") or []
+    hourly_skip = graph_series[0].get("count", 0) if graph_series else 0
+    hourly_obs_count = graph_series[1].get("count", 0) if len(graph_series) > 1 else 0
+
+    # UV: layout.primary.slots.left-minor.modules → module with "uv"
+    left_minor = _get(current, "layout", "primary", "slots", "left-minor", "modules") or []
+    uv = _find_module(left_minor, "uv").get("uv", {})
+
+    # Sunrise / moon: layout.secondary.slots.major.modules → module with "riseSet"
+    secondary = _get(current, "layout", "secondary", "slots", "major", "modules") or []
+    rise_mod = _find_module(secondary, "riseSet")
+    rise_set = rise_mod.get("riseSet", {})
+    moon_phases = rise_mod.get("moonPhases", [])
+
+    # ------------------------------------------------------------------
+    # Hourly entries
+    # ------------------------------------------------------------------
+    hourly_raw = graph.get("columns") or []
+    hourly_entries = [
+        HourlyEntry(
+            datetime=h.get("date", ""),
+            temperature=_safe_float(h.get("temperature")),
+            rainfall=_safe_float(h.get("rainfall")),
+            wind_speed=_safe_float(_get(h, "wind", "averageSpeed")),
+            wind_direction=_get(h, "wind", "direction"),
+        )
+        for h in hourly_raw
+        if isinstance(h, dict)
+    ]
+
+    # ------------------------------------------------------------------
+    # Daily entries (from 7-day JSON)
+    # ------------------------------------------------------------------
+    raw_days = _get(daily, "layout", "primary", "slots", "main", "modules", "0", "days") or []
+    daily_entries = [
+        DailyEntry(
+            datetime=_get(d, "date"),
+            condition=_get(d, "condition"),
+            temp_high=_get(d, "forecasts", "0", "highTemp"),
+            temp_low=_get(d, "forecasts", "0", "lowTemp"),
+            description=_get(d, "forecasts", "0", "statement"),
+            rainfall_low=_safe_float(_get(d, "rainFall1")),
+            rainfall_high=_safe_float(_get(d, "rainFall10")),
+        )
+        for d in raw_days
+        if isinstance(d, dict)
+    ]
+
+    # ------------------------------------------------------------------
+    # Marine — boating and surf stored nested under their own keys
+    # ------------------------------------------------------------------
+    boating = current.get("boating_data") or {}
+    surf = current.get("surf_data") or {}
+
+    # ------------------------------------------------------------------
+    # Assemble dataclass
+    # ------------------------------------------------------------------
+    return MetServicePublicData(
+        # Observations
+        temperature=_safe_float(_get(obs, "temperature", "0", "current")),
+        feels_like=_safe_float(_get(obs, "temperature", "0", "feelsLike")),
+        temp_today_high=_safe_float(_get(obs, "temperature", "0", "high")),
+        temp_today_low=_safe_float(_get(obs, "temperature", "0", "low")),
+        humidity=_safe_int(_get(obs, "rain", "0", "relativeHumidity")),
+        pressure=_safe_float(_get(obs, "pressure", "0", "atSeaLevel")),
+        pressure_trend=_get(obs, "pressure", "0", "trend"),
+        wind_speed=_safe_float(_get(obs, "wind", "0", "averageSpeed")),
+        wind_gust=_safe_float(_get(obs, "wind", "0", "gustSpeed")),
+        wind_direction=_get(obs, "wind", "0", "direction"),
+        wind_strength=_get(obs, "wind", "0", "strength"),
+        rainfall=_safe_float(_get(obs, "rain", "0", "rainfall")),
+        # Today's forecast (day 0)
+        condition=day0.get("condition") if isinstance(day0, dict) else None,
+        forecast_text=_get(day0, "forecasts", "0", "statement"),
+        issued_at=day0.get("issuedAt") if isinstance(day0, dict) else None,
+        uv_index=_get(uv, "sunProtection", "uvAlertLevel"),
+        location_name=_get(current, "location", "label"),
+        # Sub-day breakdown
+        breakdown_morning=_get(breakdown0, "morning", "condition"),
+        breakdown_afternoon=_get(breakdown0, "afternoon", "condition"),
+        breakdown_evening=_get(breakdown0, "evening", "condition"),
+        breakdown_overnight=_get(breakdown0, "overnight", "condition"),
+        # Sun / moon
+        sunrise=rise_set.get("sunRise"),
+        sunset=rise_set.get("sunSet"),
+        moonrise=rise_set.get("moonRise"),
+        moonset=rise_set.get("moonSet"),
+        moon_phase=_get(moon_phases, "0", "phase"),
+        moon_phase_date=_get(moon_phases, "0", "dateISO"),
+        # Fire weather (from day 0's fireWeatherData)
+        fire_danger=_get(day0, "fireWeatherData", "fireWeather", "danger", "dailyObservation"),
+        fire_season=_get(day0, "fireWeatherData", "fireWeather", "season", "short"),
+        # Pollen (injected at root as {"pollenLevels": {...}})
+        pollen_level=_get(current, "pollen", "pollenLevels", "level"),
+        pollen_type=_get(current, "pollen", "pollenLevels", "type"),
+        # Injected derived fields
+        weather_warnings=current.get("weather_warnings", "No warnings"),
+        tomorrow_condition=current.get("tomorrow_condition"),
+        tomorrow_temp_high=current.get("tomorrow_temp_high"),
+        tomorrow_temp_low=current.get("tomorrow_temp_low"),
+        tomorrow_description=current.get("tomorrow_description"),
+        drying_morning=current.get("drying_morning"),
+        drying_afternoon=current.get("drying_afternoon"),
+        drying_next_good_day=current.get("drying_next_good_day"),
+        # Hourly
+        hourly_entries=hourly_entries,
+        hourly_obs=hourly_obs_count,
+        hourly_skip=hourly_skip,
+        # Daily
+        daily_entries=daily_entries,
+        # Tides (injected at root as a list)
+        tides=current.get("tideImport"),
+        # Boating (injected under "boating_data" key)
+        boating_forecast=boating.get("boating_forecast"),
+        boating_status=boating.get("boating_status"),
+        boating_table=boating.get("boating_table"),
+        # Surf (injected under "surf_data" key)
+        surf_conditions=surf.get("surf_conditions"),
+        surf_rating=surf.get("surf_rating"),
+        surf_wave_height=surf.get("surf_wave_height"),
+        surf_set_face=surf.get("surf_set_face"),
+        surf_swell_direction=surf.get("surf_swell_direction"),
+        surf_swell_height=surf.get("surf_swell_height"),
+        surf_wind_direction=surf.get("surf_wind_direction"),
+        surf_wind_speed=surf.get("surf_wind_speed"),
+        surf_wind_gust=surf.get("surf_wind_gust"),
+        surf_period=surf.get("surf_period"),
+    )

--- a/custom_components/metservice_weather/strings.json
+++ b/custom_components/metservice_weather/strings.json
@@ -31,6 +31,13 @@
           "boating_url": "Select a location to get boating conditions and forecast. Choose \"None — skip\" to omit boating sensors.",
           "surf_url": "Select a surf spot to get wave height, swell, rating, and wind conditions. Choose \"None — skip\" to omit surf sensors."
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate MetService",
+        "description": "Your MetService mobile API key has been rejected. Enter a new key.",
+        "data": {
+          "mobile_api_key": "Mobile API key"
+        }
       }
     },
     "error": {
@@ -44,7 +51,9 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "not_applicable": "Reauthentication is only available for mobile API entries.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/custom_components/metservice_weather/translations/en.json
+++ b/custom_components/metservice_weather/translations/en.json
@@ -31,6 +31,13 @@
           "boating_url": "Select a location to get boating conditions and forecast. Choose \"None — skip\" to omit boating sensors.",
           "surf_url": "Select a surf spot to get wave height, swell, rating, and wind conditions. Choose \"None — skip\" to omit surf sensors."
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate MetService",
+        "description": "Your MetService mobile API key has been rejected. Enter a new key.",
+        "data": {
+          "mobile_api_key": "Mobile API key"
+        }
       }
     },
     "error": {
@@ -44,7 +51,9 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "not_applicable": "Reauthentication is only available for mobile API entries.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,8 +1,6 @@
 """Tests for the metservice_weather config flow."""
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -224,7 +222,7 @@ async def test_mobile_timeout(hass, mock_coordinator_refresh):
     marine_resp.status = 200
 
     session_mock = MagicMock()
-    session_mock.get = AsyncMock(side_effect=[marine_resp, asyncio.TimeoutError()])
+    session_mock.get = AsyncMock(side_effect=[marine_resp, TimeoutError()])
 
     with patch(
         "custom_components.metservice_weather.config_flow.async_create_clientsession",
@@ -357,3 +355,220 @@ async def test_reconfigure(hass, mock_marine_session):
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert existing_entry.data[CONF_NAME] == "Napier Updated"
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — reauth: public API entry is not applicable
+# ---------------------------------------------------------------------------
+
+async def test_reauth_public_not_applicable(hass, mock_coordinator_refresh):
+    """Reauth on a public API entry aborts with not_applicable."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{DOMAIN}-/towns-cities/regions/hawkes-bay/locations/napier",
+        data={
+            CONF_NAME: "Napier",
+            CONF_LOCATION: "/towns-cities/regions/hawkes-bay/locations/napier",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_applicable"
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — reauth: mobile API, empty key shows error
+# ---------------------------------------------------------------------------
+
+async def test_reauth_mobile_empty_key(hass, mock_coordinator_refresh):
+    """Reauth confirm with empty key shows api_key_required error."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{DOMAIN}-Mobile",
+        data={
+            CONF_NAME: "Mobile",
+            CONF_LOCATION: "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            CONF_MOBILE_API_KEY: "oldkey",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MOBILE_API_KEY: ""},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {CONF_MOBILE_API_KEY: "api_key_required"}
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — reauth: mobile API, invalid key (401)
+# ---------------------------------------------------------------------------
+
+async def test_reauth_mobile_invalid_key(hass, mock_coordinator_refresh):
+    """Reauth confirm with a rejected key shows invalid_api_key error."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{DOMAIN}-Mobile2",
+        data={
+            CONF_NAME: "Mobile2",
+            CONF_LOCATION: "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            CONF_MOBILE_API_KEY: "oldkey",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    bad_key_resp = AsyncMock()
+    bad_key_resp.status = 401
+
+    session_mock = MagicMock()
+    session_mock.get = AsyncMock(return_value=bad_key_resp)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.metservice_weather.config_flow.async_create_clientsession",
+        return_value=session_mock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MOBILE_API_KEY: "badkey"},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {CONF_MOBILE_API_KEY: "invalid_api_key"}
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — reauth: mobile API, valid key accepted
+# ---------------------------------------------------------------------------
+
+async def test_reauth_mobile_valid_key(hass, mock_coordinator_refresh):
+    """Reauth confirm with a valid key updates the entry and reloads."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{DOMAIN}-Mobile3",
+        data={
+            CONF_NAME: "Mobile3",
+            CONF_LOCATION: "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            CONF_MOBILE_API_KEY: "oldkey",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    ok_resp = AsyncMock()
+    ok_resp.status = 200
+
+    session_mock = MagicMock()
+    session_mock.get = AsyncMock(return_value=ok_resp)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.metservice_weather.config_flow.async_create_clientsession",
+        return_value=session_mock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MOBILE_API_KEY: "newvalidkey"},
+        )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_MOBILE_API_KEY] == "newvalidkey"
+
+
+# ---------------------------------------------------------------------------
+# Test 14 — reauth: network error during key validation
+# ---------------------------------------------------------------------------
+
+async def test_reauth_mobile_cannot_connect(hass, mock_coordinator_refresh):
+    """Reauth confirm with a network error shows cannot_connect error."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=f"{DOMAIN}-Mobile4",
+        data={
+            CONF_NAME: "Mobile4",
+            CONF_LOCATION: "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            CONF_MOBILE_API_KEY: "oldkey",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    session_mock = MagicMock()
+    session_mock.get = AsyncMock(side_effect=Exception("network error"))
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    with patch(
+        "custom_components.metservice_weather.config_flow.async_create_clientsession",
+        return_value=session_mock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MOBILE_API_KEY: "somekey"},
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,1175 @@
+"""Tests for WeatherUpdateCoordinator fetch paths, accessors, and error handling."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.metservice_weather.coordinator import (
+    WeatherUpdateCoordinator,
+    WeatherUpdateCoordinatorConfig,
+)
+from custom_components.metservice_weather.const import (
+    RESULTS_CURRENT,
+    RESULTS_FORECAST_DAILY,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+_PUBLIC_CURRENT = _load("napier_public_current.json")
+_PUBLIC_DAILY = _load("napier_public_daily.json")
+
+_MINIMAL_MOBILE_CURRENT = {
+    "result": {
+        "warnings": {"previews": []},
+        "hourlyForecastData": {"data": []},
+        "forecastData": {"days": []},
+        "observationData": {"pressure": 1013},
+        "genericModules": [],
+    }
+}
+_MINIMAL_MOBILE_DAILY = {"result": {"forecastData": {"days": []}}}
+
+
+def _make_config(
+    api_type="public",
+    api_key="",
+    tide_url="",
+    boating_url="",
+    surf_url="",
+) -> WeatherUpdateCoordinatorConfig:
+    return WeatherUpdateCoordinatorConfig(
+        api_url="https://www.metservice.com/publicData/webdata",
+        warnings_url="https://www.metservice.com/publicData/webdata/warnings-service",
+        api_key=api_key,
+        api_type=api_type,
+        unit_system_api="m",
+        unit_system="metric",
+        location="/towns-cities/regions/hawkes-bay/locations/napier",
+        location_name="Napier",
+        latitude="-39.49",
+        longitude="176.91",
+        tide_url=tide_url,
+        boating_url=boating_url,
+        surf_url=surf_url,
+    )
+
+
+def _make_coordinator(hass, api_type="public", **kwargs) -> WeatherUpdateCoordinator:
+    config = _make_config(api_type=api_type, **kwargs)
+    coord = WeatherUpdateCoordinator(hass, config)
+    return coord
+
+
+def _mock_response(data, status=200):
+    resp = AsyncMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=data)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Test: properties
+# ---------------------------------------------------------------------------
+
+async def test_coordinator_properties(hass):
+    coord = _make_coordinator(hass)
+    assert coord.location == "/towns-cities/regions/hawkes-bay/locations/napier"
+    assert coord.location_name == "Napier"
+    assert coord.api_type == "public"
+    assert coord.enable_tides is False
+    assert coord.enable_boating is False
+    assert coord.enable_surf is False
+
+
+async def test_coordinator_properties_with_urls(hass):
+    coord = _make_coordinator(
+        hass,
+        tide_url="https://example.com/tides",
+        boating_url="https://example.com/boating",
+        surf_url="https://example.com/surf",
+    )
+    assert coord.enable_tides is True
+    assert coord.enable_boating is True
+    assert coord.enable_surf is True
+    assert coord.tide_url == "https://example.com/tides"
+
+
+# ---------------------------------------------------------------------------
+# Test: get_from_dict (DFS)
+# ---------------------------------------------------------------------------
+
+async def test_get_from_dict_simple(hass):
+    coord = _make_coordinator(hass)
+    data = {"a": {"b": {"c": 42}}}
+    assert coord.get_from_dict(data, ["a", "b", "c"]) == 42
+
+
+async def test_get_from_dict_list_traversal(hass):
+    coord = _make_coordinator(hass)
+    data = {"items": [{"val": 1}, {"val": 2}]}
+    assert coord.get_from_dict(data, ["items", "val"]) == 1
+
+
+async def test_get_from_dict_indexed_list(hass):
+    coord = _make_coordinator(hass)
+    data = [{"val": 10}, {"val": 20}]
+    assert coord.get_from_dict(data, ["1", "val"]) == 20
+
+
+async def test_get_from_dict_missing_key(hass):
+    coord = _make_coordinator(hass)
+    data = {"a": 1}
+    assert coord.get_from_dict(data, ["b"]) is None
+
+
+async def test_get_from_dict_empty_keys(hass):
+    coord = _make_coordinator(hass)
+    assert coord.get_from_dict({"x": 1}, []) == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# Test: _check_errors
+# ---------------------------------------------------------------------------
+
+async def test_check_errors_no_errors(hass):
+    coord = _make_coordinator(hass)
+    coord._check_errors("http://x", {"data": 1})  # should not raise
+
+
+async def test_check_errors_empty_errors_list(hass):
+    coord = _make_coordinator(hass)
+    coord._check_errors("http://x", {"errors": []})  # empty list — no raise
+
+
+async def test_check_errors_raises(hass):
+    coord = _make_coordinator(hass)
+    with pytest.raises(ValueError, match="something went wrong"):
+        coord._check_errors("http://x", {"errors": [{"message": "something went wrong"}]})
+
+
+# ---------------------------------------------------------------------------
+# Test: _parse_pollen_html
+# ---------------------------------------------------------------------------
+
+async def test_parse_pollen_html_level_and_plants(hass):
+    coord = _make_coordinator(hass)
+    html = '<span class="status-high">High</span><br/>Grass, Timothy'
+    result = coord._parse_pollen_html(html)
+    assert result["level"] == "High"
+    assert "Grass" in result["type"]
+
+
+async def test_parse_pollen_html_empty(hass):
+    coord = _make_coordinator(hass)
+    result = coord._parse_pollen_html("<div>nothing here</div>")
+    assert result["level"] is None
+    assert result["type"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test: _format_timestamp
+# ---------------------------------------------------------------------------
+
+async def test_format_timestamp(hass):
+    coord = _make_coordinator(hass)
+    result = coord._format_timestamp("2024-06-15T12:00:00+12:00")
+    assert "2024-06-15" in result
+    assert result.endswith("+00:00") or "Z" in result or "UTC" in result or "00:00" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: get_public_weather — happy path
+# ---------------------------------------------------------------------------
+
+async def test_get_public_weather_returns_data(hass):
+    coord = _make_coordinator(hass)
+
+    warnings_data = {"warnings": [
+        {"name": "Strong Wind", "text": "Gale force winds", "threatPeriod": "Tonight"}
+    ]}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    responses = [
+        _mock_response(_PUBLIC_CURRENT),        # main fetch
+        _mock_response(warnings_data),          # warnings fetch
+        _mock_response(_PUBLIC_DAILY),          # 7-day fetch
+        _mock_response(pollen_data),            # pollen fetch (best-effort)
+    ]
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=responses)
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    assert RESULTS_CURRENT in result
+    assert RESULTS_FORECAST_DAILY in result
+    # Warnings injected at root
+    assert "weather_warnings" in result[RESULTS_CURRENT]
+    assert "Strong Wind" in result[RESULTS_CURRENT]["weather_warnings"]
+
+
+async def test_get_public_weather_no_warnings(hass):
+    """Empty warnings list → 'No warnings' text injected."""
+    coord = _make_coordinator(hass)
+
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    assert result[RESULTS_CURRENT]["weather_warnings"] == "No warnings"
+
+
+async def test_get_public_weather_timeout_raises_update_failed(hass):
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=TimeoutError())
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_client_error_raises_update_failed(hass):
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("conn failed"))
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_none_response_raises_update_failed(hass):
+    coord = _make_coordinator(hass)
+    resp = _mock_response(None)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=resp)
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="No current weather data"):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_api_error_raises_update_failed(hass):
+    coord = _make_coordinator(hass)
+    error_resp = {"errors": [{"message": "rate limit exceeded"}]}
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(error_resp))
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed):
+        await coord.get_public_weather()
+
+
+# ---------------------------------------------------------------------------
+# Test: get_mobile_weather — happy path
+# ---------------------------------------------------------------------------
+
+async def test_get_mobile_weather_returns_data(hass):
+    coord = _make_coordinator(hass, api_type="mobile", api_key="testkey")
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_MINIMAL_MOBILE_CURRENT),
+        _mock_response(_MINIMAL_MOBILE_DAILY),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_mobile_weather()
+    assert RESULTS_CURRENT in result
+    assert RESULTS_FORECAST_DAILY in result
+
+
+async def test_get_mobile_weather_401_raises_config_entry_auth_failed(hass):
+    coord = _make_coordinator(hass, api_type="mobile", api_key="badkey")
+    resp = _mock_response({}, status=401)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=resp)
+    coord._session = mock_session
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord.get_mobile_weather()
+
+
+async def test_get_mobile_weather_403_raises_config_entry_auth_failed(hass):
+    coord = _make_coordinator(hass, api_type="mobile", api_key="badkey")
+    resp = _mock_response({}, status=403)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=resp)
+    coord._session = mock_session
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord.get_mobile_weather()
+
+
+async def test_get_mobile_weather_timeout_raises_update_failed(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=TimeoutError())
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed):
+        await coord.get_mobile_weather()
+
+
+async def test_get_mobile_weather_none_response_raises_update_failed(hass):
+    coord = _make_coordinator(hass, api_type="mobile", api_key="key")
+    resp = _mock_response(None)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=resp)
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="No current weather data"):
+        await coord.get_mobile_weather()
+
+
+# ---------------------------------------------------------------------------
+# Test: _async_update_data dispatches correctly
+# ---------------------------------------------------------------------------
+
+async def test_async_update_data_public(hass):
+    coord = _make_coordinator(hass, api_type="public")
+    with patch.object(coord, "get_public_weather", new_callable=AsyncMock, return_value={"current": {}, "daily": {}}) as mock:
+        await coord._async_update_data()
+        mock.assert_called_once()
+
+
+async def test_async_update_data_mobile(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    with patch.object(coord, "get_mobile_weather", new_callable=AsyncMock, return_value={"current": {}, "daily": {}}) as mock:
+        await coord._async_update_data()
+        mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: get_pollen_data
+# ---------------------------------------------------------------------------
+
+async def test_get_pollen_data_success(hass):
+    coord = _make_coordinator(hass)
+    pollen_html = '<span class="status-low">Low</span><br/>Grass'
+    pollen_data = {
+        "layout": {"primary": {"slots": {"main": {"modules": [
+            {"content": [{"iconName": "pollen", "html": pollen_html}]}
+        ]}}}}
+    }
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(pollen_data))
+    coord._session = mock_session
+
+    result = await coord.get_pollen_data()
+    assert result["pollenLevels"]["level"] == "Low"
+
+
+async def test_get_pollen_data_non_200_returns_empty(hass):
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response({}, status=404))
+    coord._session = mock_session
+
+    result = await coord.get_pollen_data()
+    assert result == {"pollenLevels": {"level": None, "type": None}}
+
+
+async def test_get_pollen_data_exception_returns_empty(hass):
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=Exception("network error"))
+    coord._session = mock_session
+
+    result = await coord.get_pollen_data()
+    assert result == {"pollenLevels": {"level": None, "type": None}}
+
+
+# ---------------------------------------------------------------------------
+# Test: get_tides
+# ---------------------------------------------------------------------------
+
+async def test_get_tides_success(hass):
+    tide_data = {
+        "layout": {"primary": {"slots": {"main": {"modules": [
+            {"tideData": [{"time": "06:30", "type": "HIGH", "height": 1.8}]}
+        ]}}}}
+    }
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(tide_data))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is not None
+    assert result[0]["type"] == "HIGH"
+
+
+async def test_get_tides_non_200_returns_none(hass):
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response({}, status=404))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is None
+
+
+async def test_get_tides_none_response_returns_none(hass):
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(None))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is None
+
+
+async def test_get_tides_missing_tidedata_returns_none(hass):
+    tide_data = {"layout": {"primary": {"slots": {"main": {"modules": [{"other": "data"}]}}}}}
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(tide_data))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is None
+
+
+async def test_get_tides_network_error_returns_none(hass):
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("fail"))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: get_boating_data
+# ---------------------------------------------------------------------------
+
+async def test_get_boating_data_success(hass):
+    boating_data = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+            {
+                "view": {"text": "Good", "status": "good"},
+                "forecast": {"text": "Calm seas", "issuedAt": "2024-06-15"},
+                "table": {"columns": []},
+            }
+        ]}]}}}}
+    }
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(boating_data))
+    coord._session = mock_session
+
+    result = await coord.get_boating_data()
+    assert result["boating_status"] == "Good"
+    assert result["boating_forecast"] == "Calm seas"
+
+
+async def test_get_boating_data_non_200_returns_empty(hass):
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response({}, status=503))
+    coord._session = mock_session
+
+    assert await coord.get_boating_data() == {}
+
+
+async def test_get_boating_data_no_days_returns_empty(hass):
+    boating_data = {"layout": {"primary": {"slots": {"main": {"modules": [{"days": []}]}}}}}
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(boating_data))
+    coord._session = mock_session
+
+    assert await coord.get_boating_data() == {}
+
+
+async def test_get_boating_data_no_modules_returns_empty(hass):
+    boating_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(boating_data))
+    coord._session = mock_session
+
+    assert await coord.get_boating_data() == {}
+
+
+async def test_get_boating_data_network_error_returns_empty(hass):
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("fail"))
+    coord._session = mock_session
+
+    assert await coord.get_boating_data() == {}
+
+
+# ---------------------------------------------------------------------------
+# Test: get_surf_data
+# ---------------------------------------------------------------------------
+
+def _surf_marker(path="/marine/regions/northland/surf/locations/waihi-beach"):
+    return {
+        "action": {"modules": [{"link": {"url": path}, "value": {
+            "rating": 3,
+            "waveHeight": 1.2,
+            "setFace": 1.5,
+            "swell": {"direction": "NW", "swellHeight": 1.0},
+            "wind": {"direction": "SW", "averageSpeed": 20, "gustSpeed": 30},
+            "period": 8,
+        }}]},
+        "view": {"text": "Fair"},
+    }
+
+
+async def test_get_surf_data_success(hass):
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    surf_data = {
+        "layout": {"primary": {"map": {"markers": [_surf_marker()]}}}
+    }
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(surf_data))
+    coord._session = mock_session
+
+    result = await coord.get_surf_data()
+    assert result["surf_rating"] == 3
+    assert result["surf_conditions"] == "Fair"
+
+
+async def test_get_surf_data_no_matching_marker_returns_empty(hass):
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    surf_data = {"layout": {"primary": {"map": {"markers": []}}}}
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(surf_data))
+    coord._session = mock_session
+
+    assert await coord.get_surf_data() == {}
+
+
+async def test_get_surf_data_non_200_returns_empty(hass):
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response({}, status=404))
+    coord._session = mock_session
+
+    assert await coord.get_surf_data() == {}
+
+
+async def test_get_surf_data_network_error_returns_empty(hass):
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("fail"))
+    coord._session = mock_session
+
+    assert await coord.get_surf_data() == {}
+
+
+# ---------------------------------------------------------------------------
+# Test: expand_data_urls
+# ---------------------------------------------------------------------------
+
+async def test_expand_data_urls_replaces_node(hass):
+    coord = _make_coordinator(hass)
+    expanded = {"realData": 42}
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(expanded))
+    coord._session = mock_session
+
+    data = {"node": {"dataUrl": "/some/path"}}
+    await coord.expand_data_urls(data)
+    assert data["node"] == expanded
+
+
+async def test_expand_data_urls_non_200_sets_none(hass):
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response({}, status=500))
+    coord._session = mock_session
+
+    data = {"node": {"dataUrl": "/bad/path"}}
+    await coord.expand_data_urls(data)
+    assert data["node"] is None
+
+
+async def test_expand_data_urls_no_data_url_unchanged(hass):
+    coord = _make_coordinator(hass)
+    data = {"a": 1, "b": {"c": 2}}
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock()
+    coord._session = mock_session
+
+    await coord.expand_data_urls(data)
+    assert data == {"a": 1, "b": {"c": 2}}
+    mock_session.get.assert_not_called()
+
+
+async def test_expand_data_urls_list(hass):
+    coord = _make_coordinator(hass)
+    expanded = {"val": 99}
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(expanded))
+    coord._session = mock_session
+
+    data = [{"dataUrl": "/path"}]
+    await coord.expand_data_urls(data)
+    assert data[0] == expanded
+
+
+async def test_expand_data_urls_max_depth_guard(hass):
+    """Passing _depth > 10 should not make any HTTP calls."""
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock()
+    coord._session = mock_session
+
+    data = {"dataUrl": "/should/not/fetch"}
+    await coord.expand_data_urls(data, _depth=11)
+    mock_session.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: sensor accessors with pre-loaded data
+# ---------------------------------------------------------------------------
+
+async def test_get_current_public_known_field(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {
+        RESULTS_CURRENT: {"observations": {"temperature": [{"current": 18.5}]}},
+        RESULTS_FORECAST_DAILY: {},
+    }
+    result = coord.get_current_public("temperature")
+    assert result == 18.5
+
+
+async def test_get_current_public_unknown_field_returns_none(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    result = coord.get_current_public("nonexistent_field_xyz")
+    assert result is None
+
+
+async def test_get_current_public_missing_data_returns_none(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    result = coord.get_current_public("temperature")
+    assert result is None
+
+
+async def test_get_current_mobile_known_field(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    coord.data = {
+        RESULTS_CURRENT: {"result": {"observationData": {"pressure": 1015}}},
+        RESULTS_FORECAST_DAILY: {},
+    }
+    result = coord.get_current_mobile("pressureAltimeter")
+    assert result == 1015
+
+
+async def test_get_current_mobile_unknown_field_returns_none(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    result = coord.get_current_mobile("nonexistent_xyz")
+    assert result is None
+
+
+async def test_get_forecast_daily_public_day_count(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {
+        RESULTS_CURRENT: {},
+        RESULTS_FORECAST_DAILY: {
+            "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+                {"date": "2024-06-15", "condition": "fine", "forecasts": []},
+                {"date": "2024-06-16", "condition": "cloudy", "forecasts": []},
+            ]}]}}}}
+        },
+    }
+    assert coord.get_forecast_daily_public("", 0) == 2
+
+
+async def test_get_forecast_daily_public_field(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {
+        RESULTS_CURRENT: {},
+        RESULTS_FORECAST_DAILY: {
+            "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+                {"date": "2024-06-15", "condition": "fine", "forecasts": []}
+            ]}]}}}}
+        },
+    }
+    assert coord.get_forecast_daily_public("daily_condition", 0) == "fine"
+
+
+async def test_get_forecast_daily_public_error_returns_none(hass):
+    coord = _make_coordinator(hass)
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    assert coord.get_forecast_daily_public("daily_condition", 0) is None
+
+
+async def test_get_forecast_daily_mobile_day_count(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    coord.data = {
+        RESULTS_CURRENT: {"result": {"forecastData": {"days": [{"x": 1}, {"x": 2}]}}},
+        RESULTS_FORECAST_DAILY: {},
+    }
+    assert coord.get_forecast_daily_mobile("", 0) == 2
+
+
+async def test_get_forecast_daily_mobile_error_returns_none(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    assert coord.get_forecast_daily_mobile("daily_condition", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# Test: tide/boating/surf injected into public weather fetch
+# ---------------------------------------------------------------------------
+
+async def test_get_public_weather_injects_tides(hass):
+    """When tide_url is set, tideImport is injected into result_current."""
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+
+    tide_resp = {
+        "layout": {"primary": {"slots": {"main": {"modules": [
+            {"tideData": [{"type": "HIGH", "time": "06:00", "height": 1.5}]}
+        ]}}}}
+    }
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+        _mock_response(tide_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    assert result[RESULTS_CURRENT]["tideImport"] is not None
+
+
+async def test_get_public_weather_injects_boating(hass):
+    """When boating_url is set, boating_data is injected into result_current."""
+    boating_data_resp = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+            {"view": {"text": "Good", "status": "good"}, "forecast": {"text": "Calm", "issuedAt": ""}, "table": {"columns": []}}
+        ]}]}}}}
+    }
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+        _mock_response(boating_data_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    assert "boating_data" in result[RESULTS_CURRENT]
+
+
+async def test_get_public_weather_injects_surf(hass):
+    """When surf_url is set, surf_data is injected into result_current."""
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    surf_resp = {
+        "layout": {"primary": {"map": {"markers": [_surf_marker()]}}},
+    }
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+        _mock_response(surf_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    assert "surf_data" in result[RESULTS_CURRENT]
+
+
+async def test_get_public_weather_warnings_none_raises_update_failed(hass):
+    """When warnings fetch returns None, UpdateFailed is raised."""
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(None),   # warnings returns None
+    ])
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="No warnings data"):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_daily_none_raises_update_failed(hass):
+    """When daily forecast fetch returns None, UpdateFailed is raised."""
+    warnings_data = {"warnings": []}
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(None),  # daily returns None
+    ])
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="No daily forecast"):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_unexpected_exception_raises_update_failed(hass):
+    """An unexpected exception (not TimeoutError or ClientError) is wrapped in UpdateFailed."""
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("unexpected"))
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="Unexpected error"):
+        await coord.get_public_weather()
+
+
+async def test_get_public_weather_tomorrow_injection(hass):
+    """Tomorrow's forecast is injected from 7-day data when 2+ days present."""
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+    daily_with_tomorrow = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+            {
+                "condition": "fine",
+                "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}],
+            },
+            {
+                "condition": "cloudy",
+                "forecasts": [{"highTemp": 17, "lowTemp": 10, "statement": "Tomorrow cloudy"}],
+            },
+        ]}]}}}}
+    }
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(daily_with_tomorrow),
+        _mock_response(pollen_data),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    current = result[RESULTS_CURRENT]
+    assert current.get("tomorrow_condition") == "cloudy"
+    assert current.get("tomorrow_temp_high") == 17
+    assert current.get("tomorrow_temp_low") == 10
+    assert current.get("tomorrow_description") == "Tomorrow cloudy"
+
+
+async def test_get_public_weather_drying_wet_all_day(hass):
+    """Drying index: 'Wet all day' (bare text) path covers lines 295-298 and 302."""
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    # Build a current fixture with dryingIndex.dryingState containing a "next good day" entry
+    # and a bare "Wet all day" entry, so we exercise those branches.
+    # We'll patch get_from_dict to return the crafted state instead of relying on
+    # fixture data having a dryingIndex key.
+    coord = _make_coordinator(hass)
+
+    drying_states = [
+        {"text": "Wet all day"},
+        {"text": "Next good day: Thursday"},
+    ]
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+    ])
+    coord._session = mock_session
+
+    original_get_from_dict = coord.get_from_dict
+
+    def patched_get_from_dict(data, keys):
+        if keys == ["dryingIndex", "dryingState"]:
+            return drying_states
+        return original_get_from_dict(data, keys)
+
+    with patch.object(coord, "get_from_dict", side_effect=patched_get_from_dict):
+        result = await coord.get_public_weather()
+
+    current = result[RESULTS_CURRENT]
+    assert current.get("drying_morning") == "Wet all day"
+    assert current.get("drying_afternoon") == "Wet all day"   # mirrored from morning (line 302)
+    assert current.get("drying_next_good_day") == "Thursday"  # extracted from "Next good day: Thursday"
+
+
+async def test_get_public_weather_drying_exception_silenced(hass):
+    """Exception during drying index extraction is silenced (lines 310-311)."""
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    coord = _make_coordinator(hass)
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_PUBLIC_CURRENT),
+        _mock_response(warnings_data),
+        _mock_response(_PUBLIC_DAILY),
+        _mock_response(pollen_data),
+    ])
+    coord._session = mock_session
+
+    def patched_get_from_dict(data, keys):
+        if keys == ["dryingIndex", "dryingState"]:
+            raise RuntimeError("simulated drying error")
+        return coord.__class__.get_from_dict(coord, data, keys)
+
+    with patch.object(coord, "get_from_dict", side_effect=patched_get_from_dict):
+        result = await coord.get_public_weather()
+
+    # Should succeed without raising; drying keys simply absent
+    assert RESULTS_CURRENT in result
+
+
+# ---------------------------------------------------------------------------
+# Test: get_mobile_weather — additional coverage
+# ---------------------------------------------------------------------------
+
+async def test_get_mobile_weather_daily_none_raises_update_failed(hass):
+    """When mobile daily fetch returns None, UpdateFailed is raised."""
+    coord = _make_coordinator(hass, api_type="mobile", api_key="key")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_MINIMAL_MOBILE_CURRENT),
+        _mock_response(None),  # daily returns None → line 182
+    ])
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="No daily forecast"):
+        await coord.get_mobile_weather()
+
+
+async def test_get_mobile_weather_unexpected_exception_raises_update_failed(hass):
+    """Unexpected exception in mobile fetch is wrapped in UpdateFailed (lines 206-207)."""
+    coord = _make_coordinator(hass, api_type="mobile")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("boom"))
+    coord._session = mock_session
+
+    with pytest.raises(UpdateFailed, match="Unexpected error"):
+        await coord.get_mobile_weather()
+
+
+async def test_get_mobile_weather_injects_tides(hass):
+    """Tide data injected into mobile current when tide_url configured (line 190)."""
+    tide_resp = {
+        "layout": {"primary": {"slots": {"main": {"modules": [
+            {"tideData": [{"type": "HIGH", "time": "06:00", "height": 1.5}]}
+        ]}}}}
+    }
+    coord = _make_coordinator(hass, api_type="mobile", api_key="key", tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_MINIMAL_MOBILE_CURRENT),
+        _mock_response(_MINIMAL_MOBILE_DAILY),
+        _mock_response(tide_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_mobile_weather()
+    assert "tideImport" in result[RESULTS_CURRENT]
+
+
+async def test_get_mobile_weather_injects_boating(hass):
+    """Boating data injected into mobile current when boating_url configured (line 192)."""
+    boating_data_resp = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
+            {"view": {"text": "OK", "status": "ok"}, "forecast": {"text": "Mild", "issuedAt": ""}, "table": {"columns": []}}
+        ]}]}}}}
+    }
+    coord = _make_coordinator(hass, api_type="mobile", api_key="key", boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_MINIMAL_MOBILE_CURRENT),
+        _mock_response(_MINIMAL_MOBILE_DAILY),
+        _mock_response(boating_data_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_mobile_weather()
+    assert "boating_data" in result[RESULTS_CURRENT]
+
+
+async def test_get_mobile_weather_injects_surf(hass):
+    """Surf data injected into mobile current when surf_url configured (line 194)."""
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    surf_resp = {
+        "layout": {"primary": {"map": {"markers": [_surf_marker()]}}},
+    }
+    coord = _make_coordinator(hass, api_type="mobile", api_key="key", surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(_MINIMAL_MOBILE_CURRENT),
+        _mock_response(_MINIMAL_MOBILE_DAILY),
+        _mock_response(surf_resp),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_mobile_weather()
+    assert "surf_data" in result[RESULTS_CURRENT]
+
+
+# ---------------------------------------------------------------------------
+# Test: exception paths in marine helpers
+# ---------------------------------------------------------------------------
+
+async def test_get_tides_unexpected_exception_returns_none(hass):
+    """Unexpected exception in get_tides returns None (lines 366-368)."""
+    coord = _make_coordinator(hass, tide_url="https://example.com/tides")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("disk full"))
+    coord._session = mock_session
+
+    result = await coord.get_tides()
+    assert result is None
+
+
+async def test_get_boating_data_unexpected_exception_returns_empty(hass):
+    """Unexpected exception in get_boating_data returns {} (lines 404-406)."""
+    coord = _make_coordinator(hass, boating_url="https://example.com/boating")
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("disk full"))
+    coord._session = mock_session
+
+    assert await coord.get_boating_data() == {}
+
+
+async def test_get_surf_data_unexpected_exception_returns_empty(hass):
+    """Unexpected exception in get_surf_data returns {} (lines 472-474)."""
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("disk full"))
+    coord._session = mock_session
+
+    assert await coord.get_surf_data() == {}
+
+
+async def test_get_surf_data_bad_marker_skipped(hass):
+    """Marker without 'action' key triggers except (KeyError/IndexError/TypeError) continue (lines 444-445)."""
+    surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
+    bad_marker = {}  # missing 'action' key → KeyError
+    good_marker = _surf_marker()
+    surf_data = {
+        "layout": {"primary": {"map": {"markers": [bad_marker, good_marker]}}}
+    }
+    coord = _make_coordinator(hass, surf_url=surf_url)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=_mock_response(surf_data))
+    coord._session = mock_session
+
+    result = await coord.get_surf_data()
+    assert result["surf_rating"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Test: expand_data_urls exception path
+# ---------------------------------------------------------------------------
+
+async def test_expand_data_urls_exception_sets_none(hass):
+    """When session.get raises (not timeout/client), parent key is set to None (lines 636-639)."""
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=RuntimeError("unexpected network failure"))
+    coord._session = mock_session
+
+    data = {"node": {"dataUrl": "/some/path"}}
+    await coord.expand_data_urls(data)
+    assert data["node"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test: get_forecast_daily_mobile field access
+# ---------------------------------------------------------------------------
+
+async def test_get_forecast_daily_mobile_field_access(hass):
+    """Field access on a specific day returns the correct value (lines 594-597)."""
+    coord = _make_coordinator(hass, api_type="mobile")
+    coord.data = {
+        RESULTS_CURRENT: {"result": {"forecastData": {"days": [
+            {"forecastWord": "Fine", "forecast": "A fine sunny day.", "dateISO": "2024-06-15"},
+            {"forecastWord": "Cloudy", "forecast": "Mostly cloudy.", "dateISO": "2024-06-16"},
+        ]}}},
+        RESULTS_FORECAST_DAILY: {},
+    }
+    assert coord.get_forecast_daily_mobile("daily_condition", 0) == "Fine"
+    assert coord.get_forecast_daily_mobile("daily_condition", 1) == "Cloudy"
+    assert coord.get_forecast_daily_mobile("daily_datetime", 0) == "2024-06-15"
+
+
+async def test_get_public_weather_tomorrow_extraction_exception_silenced(hass):
+    """If tomorrow extraction raises (e.g. empty modules list → IndexError), it is silenced (lines 265-266)."""
+    import copy
+    warnings_data = {"warnings": []}
+    pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+    # modules is explicitly [] — [0] raises IndexError, caught at line 265.
+    # Use a fresh current dict to avoid cross-test mutation of _PUBLIC_CURRENT.
+    current_copy = copy.deepcopy(_PUBLIC_CURRENT)
+    # Remove any pre-existing tomorrow key so the assertion is meaningful.
+    current_copy.pop("tomorrow_condition", None)
+    daily_bad = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
+
+    coord = _make_coordinator(hass)
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=[
+        _mock_response(current_copy),
+        _mock_response(warnings_data),
+        _mock_response(daily_bad),
+        _mock_response(pollen_data),
+    ])
+    coord._session = mock_session
+
+    result = await coord.get_public_weather()
+    # Should succeed; IndexError is caught and tomorrow keys not injected.
+    assert RESULTS_CURRENT in result
+    assert "tomorrow_condition" not in result[RESULTS_CURRENT]

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,234 @@
+"""Tests for coordinator_types: _get, normalizer, and dataclass structure."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from custom_components.metservice_weather.coordinator_types import (
+    DailyEntry,
+    HourlyEntry,
+    MetServicePublicData,
+    _get,
+    _safe_float,
+    _safe_int,
+    normalize_public_data,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def napier():
+    current = json.loads((FIXTURES / "napier_public_current.json").read_text())
+    daily = json.loads((FIXTURES / "napier_public_daily.json").read_text())
+    return normalize_public_data(current, daily)
+
+
+# ---------------------------------------------------------------------------
+# _get — exact-path traversal
+# ---------------------------------------------------------------------------
+
+def test_get_simple_dict():
+    assert _get({"a": 1}, "a") == 1
+
+
+def test_get_nested():
+    assert _get({"a": {"b": 42}}, "a", "b") == 42
+
+
+def test_get_list_index():
+    assert _get(["x", "y", "z"], "1") == "y"
+
+
+def test_get_mixed():
+    data = {"items": [{"val": 10}, {"val": 20}]}
+    assert _get(data, "items", "1", "val") == 20
+
+
+def test_get_missing_key_returns_none():
+    assert _get({"a": 1}, "b") is None
+
+
+def test_get_out_of_range_returns_none():
+    assert _get([1, 2], "5") is None
+
+
+def test_get_none_data_returns_none():
+    assert _get(None, "a") is None
+
+
+def test_get_non_dict_non_list_returns_none():
+    assert _get(42, "a") is None
+
+
+def test_get_empty_path_returns_data():
+    data = {"x": 1}
+    assert _get(data) == data
+
+
+def test_get_does_not_search_depth_first():
+    # DFS would find "val" anywhere in the tree; exact-path must not.
+    data = {"level1": {"other": {"val": 999}}, "val": 42}
+    assert _get(data, "val") == 42          # top-level hit only
+    assert _get(data, "level1", "val") is None  # "val" not a direct child of level1
+
+
+# ---------------------------------------------------------------------------
+# _safe_float / _safe_int
+# ---------------------------------------------------------------------------
+
+def test_safe_float_numeric():
+    assert _safe_float("18.5") == 18.5
+    assert _safe_float(18) == 18.0
+
+
+def test_safe_float_invalid():
+    assert _safe_float(None) is None
+    assert _safe_float("n/a") is None
+
+
+def test_safe_int_numeric():
+    assert _safe_int("5") == 5
+    assert _safe_int(5.9) == 5
+
+
+def test_safe_int_invalid():
+    assert _safe_int(None) is None
+    assert _safe_int("bad") is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_public_data — against Napier fixture
+# ---------------------------------------------------------------------------
+
+def test_returns_correct_type(napier):
+    assert isinstance(napier, MetServicePublicData)
+
+
+def test_temperature_is_float(napier):
+    assert isinstance(napier.temperature, float)
+    assert -20 <= napier.temperature <= 50
+
+
+def test_humidity_is_int(napier):
+    assert isinstance(napier.humidity, int)
+    assert 0 <= napier.humidity <= 100
+
+
+def test_wind_direction_is_string(napier):
+    assert isinstance(napier.wind_direction, str)
+
+
+def test_condition_is_string(napier):
+    assert isinstance(napier.condition, str)
+
+
+def test_weather_warnings_is_string(napier):
+    assert isinstance(napier.weather_warnings, str)
+
+
+def test_pollen_level_present(napier):
+    assert napier.pollen_level is not None
+
+
+def test_tomorrow_fields_present(napier):
+    assert napier.tomorrow_condition is not None
+    assert napier.tomorrow_temp_high is not None
+
+
+def test_hourly_entries_is_list(napier):
+    assert isinstance(napier.hourly_entries, list)
+    assert len(napier.hourly_entries) > 0
+    assert isinstance(napier.hourly_entries[0], HourlyEntry)
+
+
+def test_daily_entries_is_list(napier):
+    assert isinstance(napier.daily_entries, list)
+    assert 1 <= len(napier.daily_entries) <= 14
+    assert isinstance(napier.daily_entries[0], DailyEntry)
+
+
+def test_all_daily_entries_have_condition(napier):
+    missing = [i for i, d in enumerate(napier.daily_entries) if d.condition is None]
+    assert not missing, f"Days missing condition: {missing}"
+
+
+def test_all_daily_entries_have_temp_high(napier):
+    missing = [i for i, d in enumerate(napier.daily_entries) if d.temp_high is None]
+    assert not missing, f"Days missing temp_high: {missing}"
+
+
+def test_sunrise_is_string(napier):
+    assert isinstance(napier.sunrise, str)
+
+
+def test_moon_phase_is_string(napier):
+    assert isinstance(napier.moon_phase, str)
+
+
+# ---------------------------------------------------------------------------
+# normalize_public_data — marine field extraction
+# ---------------------------------------------------------------------------
+
+def test_marine_fields_none_when_absent():
+    """With no marine data injected, all marine fields are None."""
+    result = normalize_public_data(
+        {"weather_warnings": "No warnings", "hourly_entries": [], "daily_entries": []},
+        {},
+    )
+    assert result.tides is None
+    assert result.boating_forecast is None
+    assert result.surf_conditions is None
+
+
+def test_tides_extracted_from_tide_import():
+    tides = [{"type": "HIGH", "time": "06:30", "height": 1.8}]
+    current = {
+        "weather_warnings": "No warnings",
+        "tideImport": tides,
+    }
+    result = normalize_public_data(current, {})
+    assert result.tides == tides
+
+
+def test_boating_extracted_from_boating_data():
+    current = {
+        "weather_warnings": "No warnings",
+        "boating_data": {
+            "boating_status": "Good",
+            "boating_forecast": "Calm seas",
+            "boating_table": [],
+        },
+    }
+    result = normalize_public_data(current, {})
+    assert result.boating_status == "Good"
+    assert result.boating_forecast == "Calm seas"
+
+
+def test_surf_extracted_from_surf_data():
+    current = {
+        "weather_warnings": "No warnings",
+        "surf_data": {
+            "surf_conditions": "Fair",
+            "surf_rating": 3,
+            "surf_wave_height": 1.2,
+        },
+    }
+    result = normalize_public_data(current, {})
+    assert result.surf_conditions == "Fair"
+    assert result.surf_rating == 3
+
+
+# ---------------------------------------------------------------------------
+# normalize_public_data — edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_dicts_returns_defaults():
+    """normalize_public_data must not raise on completely empty input."""
+    result = normalize_public_data({}, {})
+    assert result.temperature is None
+    assert result.daily_entries == []
+    assert result.hourly_entries == []
+    assert result.weather_warnings == "No warnings"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,309 @@
+"""Tests for WeatherSensor entity and weather_current_conditions_sensors helpers."""
+from __future__ import annotations
+
+import datetime
+from unittest.mock import patch
+
+
+from custom_components.metservice_weather.coordinator import (
+    WeatherUpdateCoordinator,
+    WeatherUpdateCoordinatorConfig,
+)
+from custom_components.metservice_weather.sensor import WeatherSensor
+from custom_components.metservice_weather.weather_current_conditions_sensors import (
+    WeatherSensorEntityDescription,
+    _safe_float,
+    _safe_int,
+    _next_tide_time,
+    current_condition_sensor_descriptions_public,
+    current_condition_sensor_descriptions_mobile,
+)
+from custom_components.metservice_weather.const import (
+    RESULTS_CURRENT,
+    RESULTS_FORECAST_DAILY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal coordinator with pre-loaded data
+# ---------------------------------------------------------------------------
+
+def _make_coordinator(hass, api_type="public") -> WeatherUpdateCoordinator:
+    config = WeatherUpdateCoordinatorConfig(
+        api_url="https://www.metservice.com/publicData/webdata",
+        warnings_url="https://www.metservice.com/publicData/webdata/warnings-service",
+        api_key="",
+        api_type=api_type,
+        unit_system_api="m",
+        unit_system="metric",
+        location="/towns-cities/regions/hawkes-bay/locations/napier",
+        location_name="Napier",
+        latitude="-39.49",
+        longitude="176.91",
+        tide_url="",
+        boating_url="",
+        surf_url="",
+    )
+    coord = WeatherUpdateCoordinator(hass, config)
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    return coord
+
+
+def _make_sensor(coordinator, key="temperature", value=18.5) -> WeatherSensor:
+    """Create a WeatherSensor with the simplest possible description."""
+    desc = WeatherSensorEntityDescription(
+        key=key,
+        name="Test Sensor",
+        value_fn=lambda data, _: data,
+        attr_fn=lambda data: {"raw": data} if data else {},
+    )
+    with patch.object(coordinator, "get_current_public", return_value=value):
+        sensor = WeatherSensor(coordinator, desc)
+    return sensor
+
+
+# ---------------------------------------------------------------------------
+# Test: helper functions in weather_current_conditions_sensors.py
+# ---------------------------------------------------------------------------
+
+def test_safe_float_none():
+    assert _safe_float(None) is None
+
+
+def test_safe_float_valid():
+    assert _safe_float("18.5") == 18.5
+    assert _safe_float(18.5) == 18.5
+
+
+def test_safe_float_invalid():
+    assert _safe_float("n/a") is None
+    assert _safe_float("") is None
+
+
+def test_safe_int_none():
+    assert _safe_int(None) is None
+
+
+def test_safe_int_valid():
+    assert _safe_int("5") == 5
+    assert _safe_int(5) == 5
+
+
+def test_safe_int_invalid():
+    assert _safe_int("n/a") is None
+
+
+def test_next_tide_time_not_list():
+    assert _next_tide_time(None, "HIGH") is None
+    assert _next_tide_time({}, "HIGH") is None
+
+
+def test_next_tide_time_future():
+    future = (datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)).isoformat()
+    tides = [{"type": "HIGH", "time": future}]
+    result = _next_tide_time(tides, "HIGH")
+    assert result is not None
+
+
+def test_next_tide_time_past_returns_none():
+    past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)).isoformat()
+    tides = [{"type": "HIGH", "time": past}]
+    result = _next_tide_time(tides, "HIGH")
+    assert result is None
+
+
+def test_next_tide_time_wrong_type_returns_none():
+    future = (datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)).isoformat()
+    tides = [{"type": "LOW", "time": future}]
+    result = _next_tide_time(tides, "HIGH")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: sensor descriptions are non-empty lists
+# ---------------------------------------------------------------------------
+
+def test_public_sensor_descriptions_non_empty():
+    assert len(current_condition_sensor_descriptions_public) > 0
+
+
+def test_mobile_sensor_descriptions_non_empty():
+    assert len(current_condition_sensor_descriptions_mobile) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test: WeatherSensor properties
+# ---------------------------------------------------------------------------
+
+async def test_sensor_name(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value=20.0)
+    assert sensor.name == "Test Sensor"
+
+
+async def test_sensor_native_value_with_data(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value=18.5)
+    # _sensor_data was set to 18.5 in the constructor; value_fn just returns data
+    assert sensor.native_value == 18.5
+
+
+async def test_sensor_native_value_none_data(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value=None)
+    assert sensor.native_value is None
+
+
+async def test_sensor_native_value_fn_error_returns_none(hass):
+    """If value_fn raises, native_value returns None without crashing."""
+    coord = _make_coordinator(hass)
+    desc = WeatherSensorEntityDescription(
+        key="temperature",
+        name="Broken Sensor",
+        value_fn=lambda data, _: 1 / 0,  # always raises
+    )
+    with patch.object(coord, "get_current_public", return_value=10.0):
+        sensor = WeatherSensor(coord, desc)
+    assert sensor.native_value is None
+
+
+async def test_sensor_extra_state_attributes_with_data(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value="some text")
+    attrs = sensor.extra_state_attributes
+    assert attrs == {"raw": "some text"}
+
+
+async def test_sensor_extra_state_attributes_none_data(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value=None)
+    assert sensor.extra_state_attributes == {}
+
+
+async def test_sensor_extra_state_attributes_fn_error_returns_empty(hass):
+    coord = _make_coordinator(hass)
+    desc = WeatherSensorEntityDescription(
+        key="temperature",
+        name="Broken Attrs",
+        value_fn=lambda data, _: data,
+        attr_fn=lambda data: 1 / 0,  # always raises
+    )
+    with patch.object(coord, "get_current_public", return_value="val"):
+        sensor = WeatherSensor(coord, desc)
+    assert sensor.extra_state_attributes == {}
+
+
+async def test_sensor_handle_coordinator_update_public(hass):
+    coord = _make_coordinator(hass)
+    sensor = _make_sensor(coord, value=10.0)
+    coord.data = {RESULTS_CURRENT: {"observations": {"temperature": [{"current": 22.5}]}}, RESULTS_FORECAST_DAILY: {}}
+    with patch.object(coord, "get_current_public", return_value=22.5), \
+         patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+    assert sensor._sensor_data == 22.5
+
+
+async def test_sensor_handle_coordinator_update_mobile(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    desc = WeatherSensorEntityDescription(
+        key="temperature",
+        name="Mobile Temp",
+        value_fn=lambda data, _: data,
+    )
+    with patch.object(coord, "get_current_mobile", return_value=15.0):
+        sensor = WeatherSensor(coord, desc)
+    with patch.object(coord, "get_current_mobile", return_value=19.0), \
+         patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
+    assert sensor._sensor_data == 19.0
+
+
+async def test_sensor_available_when_coordinator_failed(hass):
+    coord = _make_coordinator(hass)
+    coord.last_update_success = False
+    sensor = _make_sensor(coord, value=5.0)
+    assert sensor.available is False
+
+
+async def test_sensor_available_when_coordinator_ok(hass):
+    coord = _make_coordinator(hass)
+    coord.last_update_success = True
+    sensor = _make_sensor(coord, value=5.0)
+    assert sensor.available is True
+
+
+# ---------------------------------------------------------------------------
+# Test: async_setup_entry creates expected sensors
+# ---------------------------------------------------------------------------
+
+async def test_sensor_setup_entry_public_skips_tide_sensors(hass):
+    """When no tide URL, tides_high and tides_low are excluded."""
+    from custom_components.metservice_weather.sensor import (
+        async_setup_entry,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.metservice_weather.const import DOMAIN
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Napier",
+            "location": "/towns-cities/regions/hawkes-bay/locations/napier",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+
+    coord = _make_coordinator(hass)
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    with patch.object(coord, "get_current_public", return_value=None):
+        await async_setup_entry(hass, entry, add_entities)
+
+    keys = [s.entity_description.key for s in added]
+    assert "tides_high" not in keys
+    assert "tides_low" not in keys
+
+
+async def test_sensor_setup_entry_mobile(hass):
+    """Mobile API entry creates mobile sensors."""
+    from custom_components.metservice_weather.sensor import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.metservice_weather.const import DOMAIN
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Mobile",
+            "location": "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            "mobile_api_key": "key",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+
+    coord = _make_coordinator(hass, api_type="mobile")
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    with patch.object(coord, "get_current_mobile", return_value=None):
+        await async_setup_entry(hass, entry, add_entities)
+
+    assert len(added) > 0
+    keys = [s.entity_description.key for s in added]
+    assert "tides_high" not in keys

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,753 @@
+"""Tests for MetService weather entities (public and mobile)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+from custom_components.metservice_weather.coordinator import (
+    WeatherUpdateCoordinator,
+    WeatherUpdateCoordinatorConfig,
+)
+from custom_components.metservice_weather.const import (
+    RESULTS_CURRENT,
+    RESULTS_FORECAST_DAILY,
+    CONDITION_MAP,
+    DOMAIN,
+)
+from custom_components.metservice_weather.weather import (
+    MetServiceForecastPublic,
+    MetServiceForecastMobile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_coordinator(hass, api_type="public", tide_url="", boating_url="", surf_url="") -> WeatherUpdateCoordinator:
+    config = WeatherUpdateCoordinatorConfig(
+        api_url="https://www.metservice.com/publicData/webdata",
+        warnings_url="https://www.metservice.com/publicData/webdata/warnings-service",
+        api_key="",
+        api_type=api_type,
+        unit_system_api="m",
+        unit_system="metric",
+        location="/towns-cities/regions/hawkes-bay/locations/napier",
+        location_name="Napier",
+        latitude="-39.49",
+        longitude="176.91",
+        tide_url=tide_url,
+        boating_url=boating_url,
+        surf_url=surf_url,
+    )
+    coord = WeatherUpdateCoordinator(hass, config)
+    coord.data = {RESULTS_CURRENT: {}, RESULTS_FORECAST_DAILY: {}}
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Test: async_setup_entry
+# ---------------------------------------------------------------------------
+
+async def test_weather_setup_entry_public(hass):
+    from custom_components.metservice_weather.weather import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Napier",
+            "location": "/towns-cities/regions/hawkes-bay/locations/napier",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    coord = _make_coordinator(hass)
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+    assert len(added) == 1
+    assert isinstance(added[0], MetServiceForecastPublic)
+
+
+async def test_weather_setup_entry_mobile(hass):
+    from custom_components.metservice_weather.weather import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Mobile",
+            "location": "/towns-cities/regions/auckland/locations/auckland",
+            "api": "mobile",
+            "mobile_api_key": "key",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    coord = _make_coordinator(hass, api_type="mobile")
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+    assert len(added) == 1
+    assert isinstance(added[0], MetServiceForecastMobile)
+
+
+# ---------------------------------------------------------------------------
+# Test: MetServiceForecastPublic properties
+# ---------------------------------------------------------------------------
+
+async def test_public_entity_name(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert entity.name == "Napier Forecast"
+
+
+async def test_public_entity_unique_id(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert "napier" in entity.unique_id.lower()
+
+
+async def test_public_entity_temperature(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=18.5):
+        assert entity.native_temperature == 18.5
+
+
+async def test_public_entity_pressure(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=1013.0):
+        assert entity.native_pressure == 1013.0
+
+
+async def test_public_entity_humidity(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=75):
+        assert entity.humidity == 75
+
+
+async def test_public_entity_humidity_none(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=None):
+        assert entity.humidity is None
+
+
+async def test_public_entity_wind_speed(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=25.0):
+        assert entity.native_wind_speed == 25.0
+
+
+async def test_public_entity_wind_bearing(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value="NW"):
+        assert entity.wind_bearing == "NW"
+
+
+async def test_public_entity_condition_mapped(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    entity.hass = hass
+    with patch.object(coord, "get_current_public", return_value="rain"), \
+         patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=True):
+        cond = entity.condition
+    assert cond == CONDITION_MAP["rain"]
+
+
+async def test_public_entity_condition_clear_night(hass):
+    """'fine' at night → 'clear-night'."""
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    entity.hass = hass
+    with patch.object(coord, "get_current_public", return_value="fine"), \
+         patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=False):
+        cond = entity.condition
+    assert cond == "clear-night"
+
+
+async def test_public_entity_condition_unknown_passthrough(hass):
+    """Unmapped condition is passed through as-is."""
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    entity.hass = hass
+    with patch.object(coord, "get_current_public", return_value="unknown-condition"), \
+         patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=True):
+        cond = entity.condition
+    assert cond == "unknown-condition"
+
+
+async def test_public_entity_temperature_units(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert entity.native_temperature_unit is not None
+
+
+async def test_public_entity_pressure_units(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert entity.native_pressure_unit is not None
+
+
+async def test_public_entity_wind_speed_units(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert entity.native_wind_speed_unit is not None
+
+
+async def test_public_entity_precipitation_units(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    assert entity.native_precipitation_unit is not None
+
+
+# ---------------------------------------------------------------------------
+# Test: MetServiceForecastPublic forecast_hourly
+# ---------------------------------------------------------------------------
+
+async def test_public_forecast_hourly_empty_when_no_data(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=None):
+        result = entity.forecast_hourly
+    assert result == []
+
+
+async def test_public_forecast_hourly_with_data(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [
+        {
+            "date": "2024-06-15T10:00:00+12:00",
+            "temperature": 18.0,
+            "rainfall": 0.0,
+            "wind": {"speed": 15.0, "direction": "NW"},
+        },
+        {
+            "date": "2024-06-15T22:00:00+12:00",
+            "temperature": 12.0,
+            "rainfall": 0.0,
+            "wind": {"speed": 10.0, "direction": "SW"},
+        },
+    ]
+
+    def _mock_get(field):
+        if field == "hourly_temp":
+            return hourly_data
+        if field == "hourly_obs":
+            return 2
+        if field == "hourly_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert len(result) == 2
+    assert result[0]["temperature"] == 18.0
+
+
+async def test_public_forecast_hourly_heavy_rain_icon(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [{
+        "date": "2024-06-15T10:00:00+12:00",
+        "temperature": 10.0,
+        "rainfall": 10.0,  # > 6 → pouring
+        "wind": {"speed": 5.0, "direction": "N"},
+    }]
+
+    def _mock_get(field):
+        if field == "hourly_temp":
+            return hourly_data
+        if field == "hourly_obs":
+            return 1
+        if field == "hourly_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "pouring"
+
+
+async def test_public_forecast_hourly_light_rain_icon(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [{
+        "date": "2024-06-15T10:00:00+12:00",
+        "temperature": 12.0,
+        "rainfall": 2.0,  # > 0 and <= 6 → rainy
+        "wind": {"speed": 5.0, "direction": "N"},
+    }]
+
+    def _mock_get(field):
+        if field == "hourly_temp":
+            return hourly_data
+        if field == "hourly_obs":
+            return 1
+        if field == "hourly_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "rainy"
+
+
+async def test_public_forecast_hourly_windy_icon(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [{
+        "date": "2024-06-15T14:00:00+12:00",
+        "temperature": 15.0,
+        "rainfall": 0.0,
+        "wind": {"speed": 50.0, "direction": "SW"},  # > 40 → windy
+    }]
+
+    def _mock_get(field):
+        if field == "hourly_temp":
+            return hourly_data
+        if field == "hourly_obs":
+            return 1
+        if field == "hourly_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "windy"
+
+
+async def test_public_forecast_hourly_night_icon(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [{
+        "date": "2024-06-15T22:00:00+12:00",
+        "temperature": 8.0,
+        "rainfall": 0.0,
+        "wind": {"speed": 5.0, "direction": "N"},
+    }]
+
+    def _mock_get(field):
+        if field == "hourly_temp":
+            return hourly_data
+        if field == "hourly_obs":
+            return 1
+        if field == "hourly_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "clear-night"
+
+
+async def test_public_forecast_hourly_backup_fields(hass):
+    """When primary hourly fields are None, backup fields are used."""
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    hourly_data = [{
+        "date": "2024-06-15T10:00:00+12:00",
+        "temperature": 14.0,
+        "rainfall": 0.0,
+        "wind": {"speed": 10.0, "direction": "N"},
+    }]
+
+    def _mock_get(field):
+        if field in ("hourly_temp", "hourly_obs", "hourly_skip"):
+            return None
+        if field == "hourly_bkp_temp":
+            return hourly_data
+        if field == "hourly_bkp_obs":
+            return 1
+        if field == "hourly_bkp_skip":
+            return 0
+        return None
+
+    with patch.object(coord, "get_current_public", side_effect=_mock_get):
+        result = entity.forecast_hourly
+
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: MetServiceForecastPublic forecast_daily
+# ---------------------------------------------------------------------------
+
+async def test_public_forecast_daily_empty_when_no_days(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_forecast_daily_public", return_value=0):
+        result = entity.forecast_daily
+    assert result == []
+
+
+async def test_public_forecast_daily_with_data(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    def _mock_daily(field, day):
+        if field == "":
+            return 2
+        if field == "daily_condition":
+            return "fine"
+        if field == "daily_temp_high":
+            return 22.0
+        if field == "daily_temp_low":
+            return 12.0
+        if field == "daily_datetime":
+            return "2024-06-15"
+        if field == "daily_description":
+            return "Sunny day"
+        if field == "daily_rainfall_low":
+            return 0.0
+        if field == "daily_rainfall_high":
+            return 1.0
+        return None
+
+    with patch.object(coord, "get_forecast_daily_public", side_effect=_mock_daily):
+        result = entity.forecast_daily
+
+    assert len(result) == 2
+    assert result[0]["temperature"] == 22.0
+    assert result[0]["templow"] == 12.0
+    assert result[0]["condition"] == CONDITION_MAP["fine"]
+
+
+async def test_public_forecast_daily_backup_temp_fields(hass):
+    """Rural areas: backup temp/datetime fields used when primary is None."""
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+
+    def _mock_daily(field, day):
+        if field == "":
+            return 1
+        if field in ("daily_temp_high", "daily_temp_low", "daily_datetime"):
+            return None
+        if field == "daily_bkp_temp_high":
+            return 20.0
+        if field == "daily_bkp_temp_low":
+            return 10.0
+        if field == "daily_bkp_datetime":
+            return "2024-06-15"
+        if field == "daily_condition":
+            return "cloudy"
+        if field in ("daily_rainfall_low", "daily_rainfall_high", "daily_description"):
+            return None
+        return None
+
+    with patch.object(coord, "get_forecast_daily_public", side_effect=_mock_daily):
+        result = entity.forecast_daily
+
+    assert result[0]["temperature"] == 20.0
+
+
+async def test_public_async_forecast_hourly(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=None):
+        result = await entity.async_forecast_hourly()
+    assert result == []
+
+
+async def test_public_async_forecast_daily(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_forecast_daily_public", return_value=0):
+        result = await entity.async_forecast_daily()
+    assert result == []
+
+
+async def test_public_extra_state_attributes(hass):
+    coord = _make_coordinator(hass)
+    entity = MetServiceForecastPublic(coord)
+    with patch.object(coord, "get_current_public", return_value=None), \
+         patch.object(coord, "get_forecast_daily_public", return_value=0):
+        attrs = entity.extra_state_attributes
+    assert "forecast_hourly" in attrs
+    assert "forecast_daily" in attrs
+
+
+# ---------------------------------------------------------------------------
+# Test: MetServiceForecastMobile properties
+# ---------------------------------------------------------------------------
+
+async def test_mobile_entity_name(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    assert entity.name == "Napier Forecast"
+
+
+async def test_mobile_entity_temperature(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=16.0):
+        assert entity.native_temperature == 16.0
+
+
+async def test_mobile_entity_pressure(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=1010.0):
+        assert entity.native_pressure == 1010.0
+
+
+async def test_mobile_entity_humidity(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=80):
+        assert entity.humidity == 80
+
+
+async def test_mobile_entity_wind_speed(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=30.0):
+        assert entity.native_wind_speed == 30.0
+
+
+async def test_mobile_entity_wind_bearing(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value="SE"):
+        assert entity.wind_bearing == "SE"
+
+
+async def test_mobile_entity_condition_mapped(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    entity.hass = hass
+    with patch.object(coord, "get_current_mobile", return_value="cloudy"), \
+         patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=True):
+        cond = entity.condition
+    assert cond == "cloudy"
+
+
+async def test_mobile_entity_condition_clear_night(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    entity.hass = hass
+    with patch.object(coord, "get_current_mobile", return_value="fine"), \
+         patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=False):
+        cond = entity.condition
+    assert cond == "clear-night"
+
+
+async def test_mobile_entity_units(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    assert entity.native_temperature_unit is not None
+    assert entity.native_pressure_unit is not None
+    assert entity.native_wind_speed_unit is not None
+    assert entity.native_precipitation_unit is not None
+
+
+# ---------------------------------------------------------------------------
+# Test: MetServiceForecastMobile forecasts
+# ---------------------------------------------------------------------------
+
+async def test_mobile_forecast_hourly_empty_when_no_data(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=None):
+        result = entity.forecast_hourly
+    assert result == []
+
+
+async def test_mobile_forecast_hourly_with_data(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    hourly_data = [
+        {
+            "dateISO": "2024-06-15T10:00:00+12:00",
+            "temperature": 18.0,
+            "rainFall": 0.0,
+            "windSpeed": 20.0,
+            "windDir": "NW",
+        },
+        {
+            "dateISO": "2024-06-15T22:00:00+12:00",
+            "temperature": 11.0,
+            "rainFall": 0.0,
+            "windSpeed": 10.0,
+            "windDir": "S",
+        },
+    ]
+
+    with patch.object(coord, "get_current_mobile", return_value=hourly_data):
+        result = entity.forecast_hourly
+
+    assert len(result) == 2
+    assert result[0]["temperature"] == 18.0
+
+
+async def test_mobile_forecast_hourly_heavy_rain(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    hourly_data = [{
+        "dateISO": "2024-06-15T14:00:00+12:00",
+        "temperature": 10.0,
+        "rainFall": 8.0,  # > 6 → pouring
+        "windSpeed": 5.0,
+        "windDir": "N",
+    }]
+
+    with patch.object(coord, "get_current_mobile", return_value=hourly_data):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "pouring"
+
+
+async def test_mobile_forecast_hourly_light_rain(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    hourly_data = [{
+        "dateISO": "2024-06-15T14:00:00+12:00",
+        "temperature": 12.0,
+        "rainFall": 3.0,  # > 0 and <= 6 → rainy
+        "windSpeed": 5.0,
+        "windDir": "N",
+    }]
+
+    with patch.object(coord, "get_current_mobile", return_value=hourly_data):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "rainy"
+
+
+async def test_mobile_forecast_hourly_windy(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    hourly_data = [{
+        "dateISO": "2024-06-15T14:00:00+12:00",
+        "temperature": 15.0,
+        "rainFall": 0.0,
+        "windSpeed": 50.0,  # > 40 → windy
+        "windDir": "SW",
+    }]
+
+    with patch.object(coord, "get_current_mobile", return_value=hourly_data):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "windy"
+
+
+async def test_mobile_forecast_hourly_night(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    hourly_data = [{
+        "dateISO": "2024-06-15T22:00:00+12:00",
+        "temperature": 8.0,
+        "rainFall": 0.0,
+        "windSpeed": 5.0,
+        "windDir": "N",
+    }]
+
+    with patch.object(coord, "get_current_mobile", return_value=hourly_data):
+        result = entity.forecast_hourly
+
+    assert result[0]["condition"] == "clear-night"
+
+
+async def test_mobile_forecast_daily_empty(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_forecast_daily_mobile", return_value=0):
+        result = entity.forecast_daily
+    assert result == []
+
+
+async def test_mobile_forecast_daily_with_data(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+
+    def _mock_daily(field, day):
+        if field == "":
+            return 2
+        if field == "daily_condition":
+            return "rain"
+        if field == "daily_temp_high":
+            return 15.0
+        if field == "daily_temp_low":
+            return 8.0
+        if field == "daily_datetime":
+            return "2024-06-15"
+        if field == "daily_description":
+            return "Rainy day"
+        return None
+
+    with patch.object(coord, "get_forecast_daily_mobile", side_effect=_mock_daily):
+        result = entity.forecast_daily
+
+    assert len(result) == 2
+    assert result[0]["condition"] == CONDITION_MAP["rain"]
+
+
+async def test_mobile_async_forecast_hourly(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=None):
+        result = await entity.async_forecast_hourly()
+    assert result == []
+
+
+async def test_mobile_async_forecast_daily(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_forecast_daily_mobile", return_value=0):
+        result = await entity.async_forecast_daily()
+    assert result == []
+
+
+async def test_mobile_extra_state_attributes(hass):
+    coord = _make_coordinator(hass, api_type="mobile")
+    entity = MetServiceForecastMobile(coord)
+    with patch.object(coord, "get_current_mobile", return_value=None), \
+         patch.object(coord, "get_forecast_daily_mobile", return_value=0):
+        attrs = entity.extra_state_attributes
+    assert "forecast_hourly" in attrs
+    assert "forecast_daily" in attrs
+
+
+async def test_entity_unavailable_when_coordinator_fails(hass):
+    coord = _make_coordinator(hass)
+    coord.last_update_success = False
+    entity = MetServiceForecastPublic(coord)
+    assert entity.available is False


### PR DESCRIPTION
## Summary

- **Silver IQS: log hygiene** — removed duplicate `_LOGGER.error` calls immediately before `raise UpdateFailed` (HA's `DataUpdateCoordinator` already logs on first failure and recovery); demoted accessor missing-key logs to `debug`; demoted `expand_data_urls` HTTP failures to `warning`. `coordinator.py` now has zero `_LOGGER.error` calls.
- **Silver IQS: reauthentication flow** — coordinator raises `ConfigEntryAuthFailed` on HTTP 401/403 from the mobile API so HA shows a reauth notification. `config_flow.py` gains `async_step_reauth` (aborts `not_applicable` for non-mobile entries) and `async_step_reauth_confirm` (validates the new key against the live API before saving). `strings.json` / `translations/en.json` updated with the new step and abort keys.
- **Silver IQS: test coverage** — added `test_coordinator.py` (59 tests), `test_sensor.py` (20 tests), `test_weather.py` (weather entity + forecasts), plus 5 reauth scenarios in `test_config_flow.py`. Total: 213 tests at **95.09% coverage** (`--cov-fail-under=95` passes). `coordinator.py`, `sensor.py`, `weather.py`, and `weather_current_conditions_sensors.py` are all at 100%.
- **Dataclass refactor Phase 1** — new `coordinator_types.py` with `_get()` exact-path traversal, `_find_module()` for robust module scanning, `HourlyEntry` / `DailyEntry` / `MetServicePublicData` dataclasses, and `normalize_public_data()`. Nothing in the existing runtime is wired to this yet — Phase 1 is purely additive. 33 new normalizer tests.

## What a reviewer should know

**Log hygiene:** the pre-`UpdateFailed` errors were creating double log spam on every poll failure. HA's coordinator logs "Failed to fetch data" on the first failure and "Fetching data for ... succeeded" on recovery — the integration's own errors on top of that were noise.

**Reauth flow:** `ConfigEntryAuthFailed` must not be caught by the generic `except Exception` clause (it inherits from `HomeAssistantError`, not `Exception`). An explicit `except ConfigEntryAuthFailed: raise` is placed as the first except clause in `get_mobile_weather` to ensure it propagates correctly.

**Normalizer paths deviate from the plan:** the plan's `normalize_public_data` assumed short paths like `_get(current, "observations", ...)` but the real fixture nests everything under `layout.primary.slots.*`. The normalizer uses `_find_module()` to scan each slot's module list by key presence rather than hardcoded indices, making it robust to module reordering. The fire danger key is `dailyObservation` not `forecast` as the plan stated.

## Test plan

- [x] `wsl bash scripts/test.sh --cov=custom_components/metservice_weather --cov-fail-under=95` — 213 passed, 95.09%
- [x] `grep -n "_LOGGER.error" custom_components/metservice_weather/coordinator.py` — no output
- [x] Normalizer tests run against real Napier fixture: 33/33 passed
- [ ] Manual: force a 401 response from mobile API → reauth notification appears in HA UI → enter new key → integration resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)