### PR TITLE
v2026.7.0: rural location support, correct rain probabilities, green CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,8 @@ jobs:
         - name: "Install requirements"
           run: python3 -m pip install -r requirements.txt
 
-        - name: "Run"
+        - name: "Run ruff check"
           run: python3 -m ruff check .
+
+        - name: "Run ruff format check"
+          run: python3 -m ruff format --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: "Test"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  pytest:
+    name: "Pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v7.0.0"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: "Install requirements"
+        run: python3 -m pip install -r requirements.txt -r requirements-test.txt
+
+      - name: "Run pytest (coverage gate from pyproject.toml)"
+        run: python3 -m pytest tests/

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,6 +38,10 @@ lint.ignore = [
     "E731", # do not assign a lambda expression, use a def
 ]
 
+[lint.per-file-ignores]
+# Dev/CLI scripts legitimately print to the terminal.
+"scripts/*" = ["T20"]
+
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ wsl bash -c "source /home/mattn/.venv/metservice-weather/bin/activate && cd /mnt
 **WSL venv path:** `/home/mattn/.venv/metservice-weather/`
 **pytest requires WSL** — `pytest-homeassistant-custom-component` needs `fcntl` (Linux only).
 
+**CI workflows** (`.github/workflows/`): `lint.yml` (ruff check + format check),
+`test.yml` (pytest + 95% coverage gate; pins in `requirements-test.txt` — keep the
+homeassistant / pytest-homeassistant-custom-component pair matched), `validate.yml`
+(hassfest + HACS), `release.yml` (zip upload on release publish). All must be green;
+the ruff debt was cleared 2026-07-15 — don't reintroduce it.
+
 ## Key file map
 ```
 custom_components/metservice_weather/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project
 HACS custom integration for NZ weather data from MetService. Fork of `ciejer/metservice-weather`.
 - **Domain:** `metservice_weather`
-- **Version:** `1.0.1` (see `custom_components/metservice_weather/manifest.json`)
+- **Version:** `2026.7.0` (see `custom_components/metservice_weather/manifest.json`)
 - **Repo:** `https://github.com/nagelm/metservice-weather`
 - **HA min version:** 2024.2.0
 
@@ -156,13 +156,18 @@ scripts/
 
 ## Versioning convention
 
-Three-level semantic versioning: `MAJOR.MINOR.PATCH`
+Home Assistant–style calendar versioning: `YYYY.M.P` (year.month.patch, month
+**not** zero-padded — same format as HA core, e.g. `2026.7.0`).
 
-- **PATCH** (`1.0.x`) — bug fixes, no new features, no breaking changes. Bump freely.
-- **MINOR** (`1.x.0`) — new features, backwards-compatible. Bump when adding sensors, config options, or other additive changes.
-- **MAJOR** (`x.0.0`) — breaking changes or milestone releases (e.g. Core inclusion). **Only bump with explicit user agreement.**
-
-Do not bump MAJOR automatically. If a change feels like it warrants a major version bump, propose it and wait for confirmation.
+- First release in a calendar month: `YYYY.M.0`.
+- Further releases in the same month bump the patch: `2026.7.1`, `2026.7.2`, …
+- Year/month reflect the **release date**, not feature scope. There is no
+  semantic major/minor signal — call out breaking changes prominently in
+  `release_notes.md` instead.
+- Tags stay `v`-prefixed: `v2026.7.0`.
+- History: releases up to `v1.0.1` used SemVer. CalVer sorts above them
+  (2026 > 1) so HACS upgrade paths are unaffected. `1.1.0` was never released;
+  its changes ship as `2026.7.0`.
 
 ## Release workflow (CRITICAL)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ homeassistant / pytest-homeassistant-custom-component pair matched), `validate.y
 (hassfest + HACS), `release.yml` (zip upload on release publish). All must be green;
 the ruff debt was cleared 2026-07-15 — don't reintroduce it.
 
+**Fork-PR workflow policy:** Actions from fork PRs require Matt's manual
+"Approve and run" for ALL outside collaborators (set 2026-07-15 via
+`actions/permissions/fork-pr-contributor-approval = all_external_contributors`).
+Own-branch PRs and Dependabot PRs (in-repo branches) run automatically.
+Do not relax this setting.
+
 ## Key file map
 ```
 custom_components/metservice_weather/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,19 +41,34 @@ custom_components/metservice_weather/
                                          get_from_dict DFS still used for drying index extraction
   coordinator_types.py                 — MetServicePublicData dataclass + HourlyEntry + DailyEntry
                                          normalize_public_data(current, daily) → MetServicePublicData
+                                         _scan_forecasts: field lookup across all forecasts[] entries
+                                         + day level (towns AND rural page shapes)
+                                         DailyEntry.rain_prob_1mm/10mm = rainFall1/rainFall10 exceedance
+                                         probabilities (% chance of ≥1mm/≥10mm — NOT amounts)
+                                         capability flags: has_observations/has_breakdown/is_rural
+                                         tomorrow_* derived from daily_entries[1] (no injection)
   entity.py                            — MetServiceEntity(CoordinatorEntity) base class;
                                          shared DeviceInfo (identifiers, manufacturer, model, config_url)
   const.py                             — LOCATIONS list, CONDITION_MAP, unit constants, URLs
   sensor.py                            — 40+ WeatherSensor(MetServiceEntity, SensorEntity); PARALLEL_UPDATES = 0
                                          value_fn(coordinator.data, unit_system)
+                                         entity creation gated per-description via exists_fn(coordinator);
+                                         stale sensor registry entries removed at setup
   weather.py                           — MetServiceForecastPublic(MetServicePublic); PARALLEL_UPDATES = 0
                                          reads coordinator.data.* directly (typed)
+                                         daily forecast: precipitation_probability from rain_prob_1mm
+                                         (never precipitation — API has no daily amounts)
   weather_current_conditions_sensors.py— sensor definitions (translation_key, value_fn lambda, unit, device class,
-                                         suggested_display_precision)
+                                         suggested_display_precision, exists_fn gate)
+                                         gate ONLY structural absences (observations, breakdown, marine config);
+                                         UV/fire/drying/pollen are SEASONAL — never gate them
   config_flow.py                       — 2-step flow (setup → locations); public API only; reconfigure support
 tests/
-  fixtures/napier_public_current.json  — captured public API fixture (post-expand, post-inject)
-  fixtures/napier_public_daily.json    — captured 7-day forecast fixture
+  fixtures/napier_public_current.json  — captured towns-cities fixture (post-expand, post-inject)
+  fixtures/napier_public_daily.json    — captured towns-cities 7-day forecast fixture
+  fixtures/kumeu_public_current.json   — captured RURAL fixture: empty observations, no breakdown,
+                                         regional+location forecasts entries, day-level temps
+  fixtures/kumeu_public_daily.json     — captured rural 7-day forecast fixture
   test_config_flow.py                  — config flow tests
   test_coordinator_data.py             — coordinator contract tests (direct dataclass attr access)
   test_coordinator.py                  — coordinator fetch/error path tests

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A full Home Assistant weather entity with:
 
 - Current condition (correctly returns `clear-night` when the sun is below the horizon)
 - 48-hour hourly forecast — temperature, precipitation, wind speed and bearing
-- 7-day daily forecast — high/low temperature, condition, plain-English description, and precipitation range estimates
+- 7-day daily forecast — high/low temperature, condition, plain-English description, and chance of rain (MetService's probability of at least 1 mm falling that day)
 
 ---
 

--- a/custom_components/metservice_weather/__init__.py
+++ b/custom_components/metservice_weather/__init__.py
@@ -1,4 +1,5 @@
 """The MetService Weather component."""
+
 from __future__ import annotations
 
 import logging
@@ -54,5 +55,3 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version > 1:
         return False
     return True
-
-

--- a/custom_components/metservice_weather/config_flow.py
+++ b/custom_components/metservice_weather/config_flow.py
@@ -1,4 +1,5 @@
 """Config Flow to configure MetService NZ Integration."""
+
 from __future__ import annotations
 import asyncio
 import logging
@@ -54,7 +55,9 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._reconfig_entry,
                 data=self.user_info,
             )
-        return self.async_create_entry(title=self.user_info[CONF_NAME], data=self.user_info)
+        return self.async_create_entry(
+            title=self.user_info[CONF_NAME], data=self.user_info
+        )
 
     # ------------------------------------------------------------------ #
     # Entry points                                                         #
@@ -87,7 +90,9 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data = await response.json(content_type=None)
                 self.regions = data["layout"]["search"]["searchLocations"][0]["items"]
             except Exception:
-                _LOGGER.exception("Failed to fetch marine regions — marine options unavailable")
+                _LOGGER.exception(
+                    "Failed to fetch marine regions — marine options unavailable"
+                )
                 self.regions = []
 
             return self.async_show_form(
@@ -143,7 +148,7 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # Fall back to either legacy key so old entries pre-fill.
                 current_region = self.user_info.get(
                     _LEGACY_TIDE_REGION_URL,
-                    self.user_info.get(_LEGACY_BOATING_REGION, "")
+                    self.user_info.get(_LEGACY_BOATING_REGION, ""),
                 )
             for r in self.regions:
                 if r["heading"]["url"].lstrip("/") == current_region:
@@ -221,8 +226,9 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if tide_label == _SKIP:
             self.user_info[CONF_TIDE_URL] = ""
         elif self._tide_map:
-            url = self._resolve_url(tide_label, self._tide_map, self._tide_locations,
-                                    marine_region, "tides")
+            url = self._resolve_url(
+                tide_label, self._tide_map, self._tide_locations, marine_region, "tides"
+            )
             if not url:
                 errors[CONF_TIDE_URL] = "tide_location_not_found"
             else:
@@ -233,8 +239,13 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if boating_label == _SKIP:
             self.user_info[CONF_BOATING_URL] = ""
         elif self._boating_map:
-            url = self._resolve_url(boating_label, self._boating_map, self._boating_locations,
-                                    marine_region, "boating")
+            url = self._resolve_url(
+                boating_label,
+                self._boating_map,
+                self._boating_locations,
+                marine_region,
+                "boating",
+            )
             if not url:
                 errors[CONF_BOATING_URL] = "boating_location_not_found"
             else:
@@ -245,8 +256,9 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if surf_label == _SKIP:
             self.user_info[CONF_SURF_URL] = ""
         elif self._surf_map:
-            url = self._resolve_url(surf_label, self._surf_map, self._surf_locations,
-                                    marine_region, "surf")
+            url = self._resolve_url(
+                surf_label, self._surf_map, self._surf_locations, marine_region, "surf"
+            )
             if not url:
                 errors[CONF_SURF_URL] = "surf_location_not_found"
             else:
@@ -275,8 +287,7 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         def _opts(label_map: dict) -> list:
             return skip_opt + [
-                {"value": label, "label": label}
-                for label in label_map.values()
+                {"value": label, "label": label} for label in label_map.values()
             ]
 
         def _default(conf_key: str, label_map: dict) -> str:
@@ -291,17 +302,24 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = {}
         if self._tide_map:
-            schema[vol.Required(CONF_TIDE_URL, default=_default(CONF_TIDE_URL, self._tide_map))] = (
-                SelectSelector(SelectSelectorConfig(options=_opts(self._tide_map)))
-            )
+            schema[
+                vol.Required(
+                    CONF_TIDE_URL, default=_default(CONF_TIDE_URL, self._tide_map)
+                )
+            ] = SelectSelector(SelectSelectorConfig(options=_opts(self._tide_map)))
         if self._boating_map:
-            schema[vol.Required(CONF_BOATING_URL, default=_default(CONF_BOATING_URL, self._boating_map))] = (
-                SelectSelector(SelectSelectorConfig(options=_opts(self._boating_map)))
-            )
+            schema[
+                vol.Required(
+                    CONF_BOATING_URL,
+                    default=_default(CONF_BOATING_URL, self._boating_map),
+                )
+            ] = SelectSelector(SelectSelectorConfig(options=_opts(self._boating_map)))
         if self._surf_map:
-            schema[vol.Required(CONF_SURF_URL, default=_default(CONF_SURF_URL, self._surf_map))] = (
-                SelectSelector(SelectSelectorConfig(options=_opts(self._surf_map)))
-            )
+            schema[
+                vol.Required(
+                    CONF_SURF_URL, default=_default(CONF_SURF_URL, self._surf_map)
+                )
+            ] = SelectSelector(SelectSelectorConfig(options=_opts(self._surf_map)))
         return schema
 
     # ------------------------------------------------------------------ #
@@ -314,10 +332,7 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             response = await session.get(url)
         data = await response.json(content_type=None)
         for module in (
-            data.get("layout", {})
-            .get("primary", {})
-            .get("map", {})
-            .get("modules", [])
+            data.get("layout", {}).get("primary", {}).get("map", {}).get("modules", [])
         ):
             if "markers" in module:
                 return module["markers"]
@@ -334,10 +349,15 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         prefix = f"/marine/regions/{region_slug}/boating/locations/"
         resolved = [m for m in all_markers if self._marker_url(m).startswith(prefix)]
-        return resolved if resolved else [
-            m for m in all_markers
-            if isinstance(m.get("label"), dict) and m["label"].get("text")
-        ]
+        return (
+            resolved
+            if resolved
+            else [
+                m
+                for m in all_markers
+                if isinstance(m.get("label"), dict) and m["label"].get("text")
+            ]
+        )
 
     async def _fetch_surf_locations(self, session, marine_region: str) -> list:
         region_slug = marine_region.split("/")[-1]
@@ -350,10 +370,15 @@ class WeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         prefix = f"/marine/regions/{region_slug}/surf/locations/"
         resolved = [m for m in all_markers if self._marker_url(m).startswith(prefix)]
-        return resolved if resolved else [
-            m for m in all_markers
-            if isinstance(m.get("label"), dict) and m["label"].get("text")
-        ]
+        return (
+            resolved
+            if resolved
+            else [
+                m
+                for m in all_markers
+                if isinstance(m.get("label"), dict) and m["label"].get("text")
+            ]
+        )
 
     # ------------------------------------------------------------------ #
     # URL resolution helpers                                               #

--- a/custom_components/metservice_weather/const.py
+++ b/custom_components/metservice_weather/const.py
@@ -3,6 +3,7 @@
 For more details about this platform, please refer to the documentation at
 https://github.com/ciejer/metservice-weather.
 """
+
 from __future__ import annotations
 
 from typing import Final
@@ -19,7 +20,6 @@ FIELD_TEMP = "temperature"
 FIELD_WINDDIR = "windDirection"
 FIELD_WINDGUST = "windGust"
 FIELD_WINDSPEED = "windSpeed"
-
 
 
 CONDITION_MAP: Final[dict[str, str]] = {
@@ -42,662 +42,377 @@ CONDITION_MAP: Final[dict[str, str]] = {
     "thunder": "lightning",
     "wind-rain": "pouring",
     "rain-wind": "pouring",
-    "windy": "windy"
+    "windy": "windy",
 }
 
 LOCATIONS = [
     {
         "label": "Dargaville",
-        "value": "/towns-cities/regions/northland/locations/dargaville"
+        "value": "/towns-cities/regions/northland/locations/dargaville",
     },
-    {
-        "label": "Kaikohe",
-        "value": "/rural/regions/northland/locations/kaikohe"
-    },
-    {
-        "label": "Kaitaia",
-        "value": "/towns-cities/regions/northland/locations/kaitaia"
-    },
+    {"label": "Kaikohe", "value": "/rural/regions/northland/locations/kaikohe"},
+    {"label": "Kaitaia", "value": "/towns-cities/regions/northland/locations/kaitaia"},
     {
         "label": "Kaitaia Airport",
-        "value": "/towns-cities/regions/northland/locations/kaitaia-airport"
+        "value": "/towns-cities/regions/northland/locations/kaitaia-airport",
     },
     {
         "label": "Kerikeri",
-        "value": "/towns-cities/regions/northland/locations/kerikeri"
+        "value": "/towns-cities/regions/northland/locations/kerikeri",
     },
-    {
-        "label": "Paihia",
-        "value": "/towns-cities/regions/northland/locations/paihia"
-    },
-    {
-        "label": "Russell",
-        "value": "/towns-cities/regions/northland/locations/russell"
-    },
+    {"label": "Paihia", "value": "/towns-cities/regions/northland/locations/paihia"},
+    {"label": "Russell", "value": "/towns-cities/regions/northland/locations/russell"},
     {
         "label": "Whangārei",
-        "value": "/towns-cities/regions/northland/locations/whangarei"
+        "value": "/towns-cities/regions/northland/locations/whangarei",
     },
     {
         "label": "Auckland Central",
-        "value": "/towns-cities/regions/auckland/locations/auckland"
+        "value": "/towns-cities/regions/auckland/locations/auckland",
     },
-    {
-        "label": "Hunua",
-        "value": "/towns-cities/regions/auckland/locations/hunua"
-    },
-    {
-        "label": "Kumeu",
-        "value": "/rural/regions/auckland/locations/kumeu"
-    },
-    {
-        "label": "Manukau",
-        "value": "/towns-cities/regions/auckland/locations/manukau"
-    },
+    {"label": "Hunua", "value": "/towns-cities/regions/auckland/locations/hunua"},
+    {"label": "Kumeu", "value": "/rural/regions/auckland/locations/kumeu"},
+    {"label": "Manukau", "value": "/towns-cities/regions/auckland/locations/manukau"},
     {
         "label": "North Shore",
-        "value": "/towns-cities/regions/auckland/locations/north-shore"
+        "value": "/towns-cities/regions/auckland/locations/north-shore",
     },
-    {
-        "label": "Pukekohe",
-        "value": "/rural/regions/auckland/locations/pukekohe"
-    },
-    {
-        "label": "Pōkeno",
-        "value": "/towns-cities/regions/auckland/locations/pokeno"
-    },
-    {
-        "label": "Tuakau",
-        "value": "/towns-cities/regions/auckland/locations/tuakau"
-    },
+    {"label": "Pukekohe", "value": "/rural/regions/auckland/locations/pukekohe"},
+    {"label": "Pōkeno", "value": "/towns-cities/regions/auckland/locations/pokeno"},
+    {"label": "Tuakau", "value": "/towns-cities/regions/auckland/locations/tuakau"},
     {
         "label": "Waiheke Island",
-        "value": "/towns-cities/regions/auckland/locations/waiheke-island"
+        "value": "/towns-cities/regions/auckland/locations/waiheke-island",
     },
     {
         "label": "Waitakere",
-        "value": "/towns-cities/regions/auckland/locations/waitakere"
+        "value": "/towns-cities/regions/auckland/locations/waitakere",
     },
-    {
-        "label": "Warkworth",
-        "value": "/rural/regions/auckland/locations/warkworth"
-    },
-    {
-        "label": "Cambridge",
-        "value": "/rural/regions/waikato/locations/cambridge"
-    },
-    {
-        "label": "Hamilton",
-        "value": "/towns-cities/regions/waikato/locations/hamilton"
-    },
-    {
-        "label": "Huntly",
-        "value": "/rural/regions/waikato/locations/huntly"
-    },
-    {
-        "label": "Matamata",
-        "value": "/rural/regions/waikato/locations/matamata"
-    },
-    {
-        "label": "Morrinsville",
-        "value": "/rural/regions/waikato/locations/morrinsville"
-    },
-    {
-        "label": "Ngāruawāhia",
-        "value": "/rural/regions/waikato/locations/ngaruawahia"
-    },
-    {
-        "label": "Paeroa",
-        "value": "/rural/regions/waikato/locations/paeroa"
-    },
-    {
-        "label": "Putāruru",
-        "value": "/rural/regions/waikato/locations/putaruru"
-    },
-    {
-        "label": "Raglan",
-        "value": "/rural/regions/waikato/locations/raglan"
-    },
-    {
-        "label": "Te Aroha",
-        "value": "/rural/regions/waikato/locations/te-aroha"
-    },
-    {
-        "label": "Te Awamutu",
-        "value": "/rural/regions/waikato/locations/te-awamutu"
-    },
-    {
-        "label": "Tokoroa",
-        "value": "/towns-cities/regions/waikato/locations/tokoroa"
-    },
-    {
-        "label": "Piopio",
-        "value": "/rural/regions/waitomo/locations/piopio"
-    },
-    {
-        "label": "Te Kuiti",
-        "value": "/towns-cities/regions/waitomo/locations/te-kuiti"
-    },
-    {
-        "label": "Waitomo",
-        "value": "/rural/regions/waitomo/locations/waitomo"
-    },
-    {
-        "label": "Thames",
-        "value": "/towns-cities/regions/coromandel/locations/thames"
-    },
-    {
-        "label": "Waihi",
-        "value": "/rural/regions/coromandel/locations/waihi"
-    },
+    {"label": "Warkworth", "value": "/rural/regions/auckland/locations/warkworth"},
+    {"label": "Cambridge", "value": "/rural/regions/waikato/locations/cambridge"},
+    {"label": "Hamilton", "value": "/towns-cities/regions/waikato/locations/hamilton"},
+    {"label": "Huntly", "value": "/rural/regions/waikato/locations/huntly"},
+    {"label": "Matamata", "value": "/rural/regions/waikato/locations/matamata"},
+    {"label": "Morrinsville", "value": "/rural/regions/waikato/locations/morrinsville"},
+    {"label": "Ngāruawāhia", "value": "/rural/regions/waikato/locations/ngaruawahia"},
+    {"label": "Paeroa", "value": "/rural/regions/waikato/locations/paeroa"},
+    {"label": "Putāruru", "value": "/rural/regions/waikato/locations/putaruru"},
+    {"label": "Raglan", "value": "/rural/regions/waikato/locations/raglan"},
+    {"label": "Te Aroha", "value": "/rural/regions/waikato/locations/te-aroha"},
+    {"label": "Te Awamutu", "value": "/rural/regions/waikato/locations/te-awamutu"},
+    {"label": "Tokoroa", "value": "/towns-cities/regions/waikato/locations/tokoroa"},
+    {"label": "Piopio", "value": "/rural/regions/waitomo/locations/piopio"},
+    {"label": "Te Kuiti", "value": "/towns-cities/regions/waitomo/locations/te-kuiti"},
+    {"label": "Waitomo", "value": "/rural/regions/waitomo/locations/waitomo"},
+    {"label": "Thames", "value": "/towns-cities/regions/coromandel/locations/thames"},
+    {"label": "Waihi", "value": "/rural/regions/coromandel/locations/waihi"},
     {
         "label": "Waikawau Bay",
-        "value": "/rural/regions/coromandel/locations/waikawau-bay"
+        "value": "/rural/regions/coromandel/locations/waikawau-bay",
     },
-    {
-        "label": "Whangamatā",
-        "value": "/rural/regions/coromandel/locations/whangamata"
-    },
+    {"label": "Whangamatā", "value": "/rural/regions/coromandel/locations/whangamata"},
     {
         "label": "Whitianga",
-        "value": "/towns-cities/regions/coromandel/locations/whitianga"
+        "value": "/towns-cities/regions/coromandel/locations/whitianga",
     },
     {
         "label": "Ngongotahā",
-        "value": "/towns-cities/regions/rotorua/locations/ngongotaha"
+        "value": "/towns-cities/regions/rotorua/locations/ngongotaha",
     },
-    {
-        "label": "Rotorua",
-        "value": "/towns-cities/regions/rotorua/locations/rotorua"
-    },
-    {
-        "label": "Katikati",
-        "value": "/rural/regions/bay-of-plenty/locations/katikati"
-    },
-    {
-        "label": "Kawerau",
-        "value": "/rural/regions/bay-of-plenty/locations/kawerau"
-    },
+    {"label": "Rotorua", "value": "/towns-cities/regions/rotorua/locations/rotorua"},
+    {"label": "Katikati", "value": "/rural/regions/bay-of-plenty/locations/katikati"},
+    {"label": "Kawerau", "value": "/rural/regions/bay-of-plenty/locations/kawerau"},
     {
         "label": "Mount Maunganui",
-        "value": "/towns-cities/regions/bay-of-plenty/locations/mount-maunganui"
+        "value": "/towns-cities/regions/bay-of-plenty/locations/mount-maunganui",
     },
-    {
-        "label": "Opotiki",
-        "value": "/rural/regions/bay-of-plenty/locations/opotiki"
-    },
-    {
-        "label": "Papamoa",
-        "value": "/rural/regions/bay-of-plenty/locations/papamoa"
-    },
+    {"label": "Opotiki", "value": "/rural/regions/bay-of-plenty/locations/opotiki"},
+    {"label": "Papamoa", "value": "/rural/regions/bay-of-plenty/locations/papamoa"},
     {
         "label": "Tauranga",
-        "value": "/towns-cities/regions/bay-of-plenty/locations/tauranga"
+        "value": "/towns-cities/regions/bay-of-plenty/locations/tauranga",
     },
-    {
-        "label": "Te Puke",
-        "value": "/rural/regions/bay-of-plenty/locations/te-puke"
-    },
+    {"label": "Te Puke", "value": "/rural/regions/bay-of-plenty/locations/te-puke"},
     {
         "label": "Whakatāne",
-        "value": "/towns-cities/regions/bay-of-plenty/locations/whakatane"
+        "value": "/towns-cities/regions/bay-of-plenty/locations/whakatane",
     },
-    {
-        "label": "Ōhope",
-        "value": "/towns-cities/regions/bay-of-plenty/locations/ohope"
-    },
+    {"label": "Ōhope", "value": "/towns-cities/regions/bay-of-plenty/locations/ohope"},
     {
         "label": "Ōmokoroa",
-        "value": "/towns-cities/regions/bay-of-plenty/locations/omokoroa"
+        "value": "/towns-cities/regions/bay-of-plenty/locations/omokoroa",
     },
-    {
-        "label": "Taupō",
-        "value": "/towns-cities/regions/taupo/locations/taupo"
-    },
+    {"label": "Taupō", "value": "/towns-cities/regions/taupo/locations/taupo"},
     {
         "label": "Taupō Airport",
-        "value": "/towns-cities/regions/taupo/locations/taupo-airport"
+        "value": "/towns-cities/regions/taupo/locations/taupo-airport",
     },
-    {
-        "label": "Tūrangi",
-        "value": "/rural/regions/taupo/locations/turangi"
-    },
-    {
-        "label": "Gisborne",
-        "value": "/towns-cities/regions/gisborne/locations/gisborne"
-    },
-    {
-        "label": "Ruatoria",
-        "value": "/rural/regions/gisborne/locations/ruatoria"
-    },
+    {"label": "Tūrangi", "value": "/rural/regions/taupo/locations/turangi"},
+    {"label": "Gisborne", "value": "/towns-cities/regions/gisborne/locations/gisborne"},
+    {"label": "Ruatoria", "value": "/rural/regions/gisborne/locations/ruatoria"},
     {
         "label": "Eastern Rangitaiki",
-        "value": "/rural/regions/hawkes-bay/locations/eastern-rangitaiki"
+        "value": "/rural/regions/hawkes-bay/locations/eastern-rangitaiki",
     },
     {
         "label": "Hastings",
-        "value": "/towns-cities/regions/hawkes-bay/locations/hastings"
+        "value": "/towns-cities/regions/hawkes-bay/locations/hastings",
     },
     {
         "label": "Havelock North",
-        "value": "/towns-cities/regions/hawkes-bay/locations/havelock-north"
+        "value": "/towns-cities/regions/hawkes-bay/locations/havelock-north",
     },
-    {
-        "label": "Mahia",
-        "value": "/rural/regions/hawkes-bay/locations/mahia"
-    },
-    {
-        "label": "Napier",
-        "value": "/towns-cities/regions/hawkes-bay/locations/napier"
-    },
+    {"label": "Mahia", "value": "/rural/regions/hawkes-bay/locations/mahia"},
+    {"label": "Napier", "value": "/towns-cities/regions/hawkes-bay/locations/napier"},
     {
         "label": "Napier Airport",
-        "value": "/towns-cities/regions/hawkes-bay/locations/napier-airport"
+        "value": "/towns-cities/regions/hawkes-bay/locations/napier-airport",
     },
-    {
-        "label": "Waipukurau",
-        "value": "/rural/regions/hawkes-bay/locations/waipukurau"
-    },
-    {
-        "label": "Wairoa",
-        "value": "/rural/regions/hawkes-bay/locations/wairoa"
-    },
-    {
-        "label": "Eltham",
-        "value": "/rural/regions/taranaki/locations/eltham"
-    },
-    {
-        "label": "Hāwera",
-        "value": "/rural/regions/taranaki/locations/hawera"
-    },
-    {
-        "label": "Inglewood",
-        "value": "/rural/regions/taranaki/locations/inglewood"
-    },
+    {"label": "Waipukurau", "value": "/rural/regions/hawkes-bay/locations/waipukurau"},
+    {"label": "Wairoa", "value": "/rural/regions/hawkes-bay/locations/wairoa"},
+    {"label": "Eltham", "value": "/rural/regions/taranaki/locations/eltham"},
+    {"label": "Hāwera", "value": "/rural/regions/taranaki/locations/hawera"},
+    {"label": "Inglewood", "value": "/rural/regions/taranaki/locations/inglewood"},
     {
         "label": "New Plymouth",
-        "value": "/towns-cities/regions/taranaki/locations/new-plymouth"
+        "value": "/towns-cities/regions/taranaki/locations/new-plymouth",
     },
     {
         "label": "New Plymouth Airport",
-        "value": "/towns-cities/regions/taranaki/locations/new-plymouth-airport"
+        "value": "/towns-cities/regions/taranaki/locations/new-plymouth-airport",
     },
-    {
-        "label": "Opunake",
-        "value": "/rural/regions/taranaki/locations/opunake"
-    },
-    {
-        "label": "Stratford",
-        "value": "/rural/regions/taranaki/locations/stratford"
-    },
+    {"label": "Opunake", "value": "/rural/regions/taranaki/locations/opunake"},
+    {"label": "Stratford", "value": "/rural/regions/taranaki/locations/stratford"},
     {
         "label": "Taumarunui",
-        "value": "/towns-cities/regions/taumarunui/locations/taumarunui"
+        "value": "/towns-cities/regions/taumarunui/locations/taumarunui",
     },
-    {
-        "label": "Ohakune",
-        "value": "/rural/regions/taihape/locations/ohakune"
-    },
-    {
-        "label": "Waiouru",
-        "value": "/rural/regions/taihape/locations/waiouru"
-    },
+    {"label": "Ohakune", "value": "/rural/regions/taihape/locations/ohakune"},
+    {"label": "Waiouru", "value": "/rural/regions/taihape/locations/waiouru"},
     {
         "label": "Whanganui",
-        "value": "/towns-cities/regions/wanganui/locations/wanganui"
+        "value": "/towns-cities/regions/wanganui/locations/wanganui",
     },
     {
         "label": "Whanganui Airport",
-        "value": "/towns-cities/regions/wanganui/locations/wanganui-airport"
+        "value": "/towns-cities/regions/wanganui/locations/wanganui-airport",
     },
-    {
-        "label": "Feilding",
-        "value": "/rural/regions/manawatu/locations/feilding"
-    },
-    {
-        "label": "Hunterville",
-        "value": "/rural/regions/manawatu/locations/hunterville"
-    },
-    {
-        "label": "Ohakea",
-        "value": "/rural/regions/manawatu/locations/ohakea"
-    },
+    {"label": "Feilding", "value": "/rural/regions/manawatu/locations/feilding"},
+    {"label": "Hunterville", "value": "/rural/regions/manawatu/locations/hunterville"},
+    {"label": "Ohakea", "value": "/rural/regions/manawatu/locations/ohakea"},
     {
         "label": "Palmerston North",
-        "value": "/towns-cities/regions/manawatu/locations/palmerston-north"
+        "value": "/towns-cities/regions/manawatu/locations/palmerston-north",
     },
     {
         "label": "Palmerston North Airport",
-        "value": "/towns-cities/regions/manawatu/locations/palmerston-north-airport"
+        "value": "/towns-cities/regions/manawatu/locations/palmerston-north-airport",
     },
-    {
-        "label": "Carterton",
-        "value": "/rural/regions/wairarapa/locations/carterton"
-    },
-    {
-        "label": "Castlepoint",
-        "value": "/rural/regions/wairarapa/locations/castlepoint"
-    },
+    {"label": "Carterton", "value": "/rural/regions/wairarapa/locations/carterton"},
+    {"label": "Castlepoint", "value": "/rural/regions/wairarapa/locations/castlepoint"},
     {
         "label": "Dannevirke",
-        "value": "/towns-cities/regions/wairarapa/locations/dannevirke"
+        "value": "/towns-cities/regions/wairarapa/locations/dannevirke",
     },
-    {
-        "label": "Featherston",
-        "value": "/rural/regions/wairarapa/locations/featherston"
-    },
+    {"label": "Featherston", "value": "/rural/regions/wairarapa/locations/featherston"},
     {
         "label": "Martinborough",
-        "value": "/rural/regions/wairarapa/locations/martinborough"
+        "value": "/rural/regions/wairarapa/locations/martinborough",
     },
     {
         "label": "Masterton",
-        "value": "/towns-cities/regions/wairarapa/locations/masterton"
+        "value": "/towns-cities/regions/wairarapa/locations/masterton",
     },
     {
         "label": "Levin",
-        "value": "/towns-cities/regions/kapiti-horowhenua/locations/levin"
+        "value": "/towns-cities/regions/kapiti-horowhenua/locations/levin",
     },
     {
         "label": "Paraparaumu",
-        "value": "/towns-cities/regions/kapiti-horowhenua/locations/paraparaumu"
+        "value": "/towns-cities/regions/kapiti-horowhenua/locations/paraparaumu",
     },
-    {
-        "label": "Te Horo",
-        "value": "/rural/regions/kapiti-horowhenua/locations/te-horo"
-    },
+    {"label": "Te Horo", "value": "/rural/regions/kapiti-horowhenua/locations/te-horo"},
     {
         "label": "Waikanae",
-        "value": "/towns-cities/regions/kapiti-horowhenua/locations/waikanae"
+        "value": "/towns-cities/regions/kapiti-horowhenua/locations/waikanae",
     },
-    {
-        "label": "Ōtaki",
-        "value": "/rural/regions/kapiti-horowhenua/locations/otaki"
-    },
-    {
-        "label": "Judgeford",
-        "value": "/rural/regions/wellington/locations/judgeford"
-    },
+    {"label": "Ōtaki", "value": "/rural/regions/kapiti-horowhenua/locations/otaki"},
+    {"label": "Judgeford", "value": "/rural/regions/wellington/locations/judgeford"},
     {
         "label": "Lower Hutt",
-        "value": "/towns-cities/regions/wellington/locations/lower-hutt"
+        "value": "/towns-cities/regions/wellington/locations/lower-hutt",
     },
     {
         "label": "Lyall Bay",
-        "value": "/towns-cities/regions/wellington/locations/lyall-bay"
+        "value": "/towns-cities/regions/wellington/locations/lyall-bay",
     },
     {
         "label": "Ohariu Valley",
-        "value": "/rural/regions/wellington/locations/ohariu-valley"
+        "value": "/rural/regions/wellington/locations/ohariu-valley",
     },
-    {
-        "label": "Porirua",
-        "value": "/towns-cities/regions/wellington/locations/porirua"
-    },
+    {"label": "Porirua", "value": "/towns-cities/regions/wellington/locations/porirua"},
     {
         "label": "Upper Hutt",
-        "value": "/towns-cities/regions/wellington/locations/upper-hutt"
+        "value": "/towns-cities/regions/wellington/locations/upper-hutt",
     },
     {
         "label": "Wainuiomata",
-        "value": "/towns-cities/regions/wellington/locations/wainuiomata"
+        "value": "/towns-cities/regions/wellington/locations/wainuiomata",
     },
     {
         "label": "Wellington Central",
-        "value": "/towns-cities/regions/wellington/locations/wellington"
+        "value": "/towns-cities/regions/wellington/locations/wellington",
     },
     {
         "label": "Blenheim",
-        "value": "/towns-cities/regions/marlborough/locations/blenheim"
+        "value": "/towns-cities/regions/marlborough/locations/blenheim",
     },
     {
         "label": "Kaikōura",
-        "value": "/towns-cities/regions/marlborough/locations/kaikoura"
+        "value": "/towns-cities/regions/marlborough/locations/kaikoura",
     },
     {
         "label": "Kaikōura Airport",
-        "value": "/towns-cities/regions/marlborough/locations/kaikoura-airport"
+        "value": "/towns-cities/regions/marlborough/locations/kaikoura-airport",
     },
-    {
-        "label": "Picton",
-        "value": "/rural/regions/marlborough/locations/picton"
-    },
-    {
-        "label": "Golden Bay",
-        "value": "/rural/regions/nelson"
-    },
-    {
-        "label": "Motueka",
-        "value": "/towns-cities/regions/nelson/locations/motueka"
-    },
-    {
-        "label": "Murchison",
-        "value": "/rural/regions/nelson/locations/murchison"
-    },
-    {
-        "label": "Nelson",
-        "value": "/towns-cities/regions/nelson/locations/nelson"
-    },
-    {
-        "label": "Richmond",
-        "value": "/towns-cities/regions/nelson/locations/richmond"
-    },
-    {
-        "label": "St Arnaud",
-        "value": "/rural/regions/nelson/locations/st-arnaud"
-    },
-    {
-        "label": "Takaka",
-        "value": "/rural/regions/nelson/locations/takaka"
-    },
-    {
-        "label": "Reefton",
-        "value": "/towns-cities/regions/buller/locations/reefton"
-    },
-    {
-        "label": "Westport",
-        "value": "/towns-cities/regions/buller/locations/westport"
-    },
-    {
-        "label": "Franz Josef",
-        "value": "/rural/regions/westland/locations/franz-josef"
-    },
+    {"label": "Picton", "value": "/rural/regions/marlborough/locations/picton"},
+    {"label": "Golden Bay", "value": "/rural/regions/nelson"},
+    {"label": "Motueka", "value": "/towns-cities/regions/nelson/locations/motueka"},
+    {"label": "Murchison", "value": "/rural/regions/nelson/locations/murchison"},
+    {"label": "Nelson", "value": "/towns-cities/regions/nelson/locations/nelson"},
+    {"label": "Richmond", "value": "/towns-cities/regions/nelson/locations/richmond"},
+    {"label": "St Arnaud", "value": "/rural/regions/nelson/locations/st-arnaud"},
+    {"label": "Takaka", "value": "/rural/regions/nelson/locations/takaka"},
+    {"label": "Reefton", "value": "/towns-cities/regions/buller/locations/reefton"},
+    {"label": "Westport", "value": "/towns-cities/regions/buller/locations/westport"},
+    {"label": "Franz Josef", "value": "/rural/regions/westland/locations/franz-josef"},
     {
         "label": "Greymouth",
-        "value": "/towns-cities/regions/westland/locations/greymouth"
+        "value": "/towns-cities/regions/westland/locations/greymouth",
     },
-    {
-        "label": "Haast",
-        "value": "/rural/regions/westland/locations/haast"
-    },
-    {
-        "label": "Hokitika",
-        "value": "/towns-cities/regions/westland/locations/hokitika"
-    },
+    {"label": "Haast", "value": "/rural/regions/westland/locations/haast"},
+    {"label": "Hokitika", "value": "/towns-cities/regions/westland/locations/hokitika"},
     {
         "label": "Ashburton",
-        "value": "/towns-cities/regions/canterbury-plains/locations/ashburton"
+        "value": "/towns-cities/regions/canterbury-plains/locations/ashburton",
     },
     {
         "label": "Darfield",
-        "value": "/rural/regions/canterbury-plains/locations/darfield"
+        "value": "/rural/regions/canterbury-plains/locations/darfield",
     },
-    {
-        "label": "Kaiapoi",
-        "value": "/rural/regions/canterbury-plains/locations/kaiapoi"
-    },
-    {
-        "label": "Methven",
-        "value": "/rural/regions/canterbury-plains/locations/methven"
-    },
-    {
-        "label": "Pegasus",
-        "value": "/rural/regions/canterbury-plains/locations/pegasus"
-    },
-    {
-        "label": "Rakaia",
-        "value": "/rural/regions/canterbury-plains/locations/rakaia"
-    },
-    {
-        "label": "Temuka",
-        "value": "/rural/regions/canterbury-plains/locations/temuka"
-    },
+    {"label": "Kaiapoi", "value": "/rural/regions/canterbury-plains/locations/kaiapoi"},
+    {"label": "Methven", "value": "/rural/regions/canterbury-plains/locations/methven"},
+    {"label": "Pegasus", "value": "/rural/regions/canterbury-plains/locations/pegasus"},
+    {"label": "Rakaia", "value": "/rural/regions/canterbury-plains/locations/rakaia"},
+    {"label": "Temuka", "value": "/rural/regions/canterbury-plains/locations/temuka"},
     {
         "label": "Timaru",
-        "value": "/towns-cities/regions/canterbury-plains/locations/timaru"
+        "value": "/towns-cities/regions/canterbury-plains/locations/timaru",
     },
-    {
-        "label": "Waimate",
-        "value": "/rural/regions/canterbury-plains/locations/waimate"
-    },
-    {
-        "label": "Waipara",
-        "value": "/rural/regions/canterbury-plains/locations/waipara"
-    },
+    {"label": "Waimate", "value": "/rural/regions/canterbury-plains/locations/waimate"},
+    {"label": "Waipara", "value": "/rural/regions/canterbury-plains/locations/waipara"},
     {
         "label": "Culverden",
-        "value": "/rural/regions/canterbury-high-country/locations/culverden"
+        "value": "/rural/regions/canterbury-high-country/locations/culverden",
     },
     {
         "label": "Hanmer Springs",
-        "value": "/rural/regions/canterbury-high-country/locations/hanmer-springs"
+        "value": "/rural/regions/canterbury-high-country/locations/hanmer-springs",
     },
     {
         "label": "Mount Cook",
-        "value": "/towns-cities/regions/canterbury-high-country/locations/mount-cook"
+        "value": "/towns-cities/regions/canterbury-high-country/locations/mount-cook",
     },
     {
         "label": "Omarama",
-        "value": "/rural/regions/canterbury-high-country/locations/omarama"
+        "value": "/rural/regions/canterbury-high-country/locations/omarama",
     },
     {
         "label": "Twizel",
-        "value": "/rural/regions/canterbury-high-country/locations/twizel"
+        "value": "/rural/regions/canterbury-high-country/locations/twizel",
     },
     {
         "label": "Banks Peninsula",
-        "value": "/towns-cities/regions/christchurch/locations/banks-peninsula"
+        "value": "/towns-cities/regions/christchurch/locations/banks-peninsula",
     },
     {
         "label": "Christchurch Central",
-        "value": "/towns-cities/regions/christchurch/locations/christchurch"
+        "value": "/towns-cities/regions/christchurch/locations/christchurch",
     },
     {
         "label": "Eastern Suburbs",
-        "value": "/towns-cities/regions/christchurch/locations/eastern-suburbs"
+        "value": "/towns-cities/regions/christchurch/locations/eastern-suburbs",
     },
-    {
-        "label": "Hilltop",
-        "value": "/rural/regions/christchurch/locations/hill-top"
-    },
-    {
-        "label": "Lincoln",
-        "value": "/rural/regions/christchurch/locations/lincoln"
-    },
-    {
-        "label": "Marshland",
-        "value": "/rural/regions/christchurch/locations/marshlands"
-    },
+    {"label": "Hilltop", "value": "/rural/regions/christchurch/locations/hill-top"},
+    {"label": "Lincoln", "value": "/rural/regions/christchurch/locations/lincoln"},
+    {"label": "Marshland", "value": "/rural/regions/christchurch/locations/marshlands"},
     {
         "label": "Port Hills",
-        "value": "/towns-cities/regions/christchurch/locations/port-hills"
+        "value": "/towns-cities/regions/christchurch/locations/port-hills",
     },
     {
         "label": "Prebbleton",
-        "value": "/towns-cities/regions/christchurch/locations/prebbleton"
+        "value": "/towns-cities/regions/christchurch/locations/prebbleton",
     },
     {
         "label": "Rolleston",
-        "value": "/towns-cities/regions/christchurch/locations/rolleston"
+        "value": "/towns-cities/regions/christchurch/locations/rolleston",
     },
-    {
-        "label": "Oamaru",
-        "value": "/towns-cities/regions/north-otago/locations/oamaru"
-    },
+    {"label": "Oamaru", "value": "/towns-cities/regions/north-otago/locations/oamaru"},
     {
         "label": "Oamaru Airport",
-        "value": "/towns-cities/regions/north-otago/locations/oamaru-airport"
+        "value": "/towns-cities/regions/north-otago/locations/oamaru-airport",
     },
     {
         "label": "Alexandra",
-        "value": "/towns-cities/regions/central-otago/locations/alexandra"
+        "value": "/towns-cities/regions/central-otago/locations/alexandra",
     },
-    {
-        "label": "Cromwell",
-        "value": "/rural/regions/central-otago/locations/cromwell"
-    },
-    {
-        "label": "Dunedin",
-        "value": "/towns-cities/regions/dunedin/locations/dunedin"
-    },
+    {"label": "Cromwell", "value": "/rural/regions/central-otago/locations/cromwell"},
+    {"label": "Dunedin", "value": "/towns-cities/regions/dunedin/locations/dunedin"},
     {
         "label": "Leith Saddle",
-        "value": "/towns-cities/regions/dunedin/locations/leith-saddle"
+        "value": "/towns-cities/regions/dunedin/locations/leith-saddle",
     },
-    {
-        "label": "Middlemarch",
-        "value": "/rural/regions/dunedin/locations/middlemarch"
-    },
-    {
-        "label": "Mosgiel",
-        "value": "/towns-cities/regions/dunedin/locations/mosgiel"
-    },
+    {"label": "Middlemarch", "value": "/rural/regions/dunedin/locations/middlemarch"},
+    {"label": "Mosgiel", "value": "/towns-cities/regions/dunedin/locations/mosgiel"},
     {
         "label": "Port Chalmers",
-        "value": "/towns-cities/regions/dunedin/locations/port-chalmers"
+        "value": "/towns-cities/regions/dunedin/locations/port-chalmers",
     },
-    {
-        "label": "Waitati",
-        "value": "/rural/regions/dunedin/locations/waitati"
-    },
-    {
-        "label": "Balclutha",
-        "value": "/rural/regions/clutha/locations/balclutha"
-    },
-    {
-        "label": "Nugget Point",
-        "value": "/rural/regions/clutha/locations/nugget-point"
-    },
+    {"label": "Waitati", "value": "/rural/regions/dunedin/locations/waitati"},
+    {"label": "Balclutha", "value": "/rural/regions/clutha/locations/balclutha"},
+    {"label": "Nugget Point", "value": "/rural/regions/clutha/locations/nugget-point"},
     {
         "label": "Glenorchy",
-        "value": "/rural/regions/southern-lakes/locations/glenorchy"
+        "value": "/rural/regions/southern-lakes/locations/glenorchy",
     },
     {
         "label": "Lake Hayes",
-        "value": "/rural/regions/southern-lakes/locations/lake-hayes"
+        "value": "/rural/regions/southern-lakes/locations/lake-hayes",
     },
     {
         "label": "Queenstown",
-        "value": "/towns-cities/regions/southern-lakes/locations/queenstown"
+        "value": "/towns-cities/regions/southern-lakes/locations/queenstown",
     },
     {
         "label": "Wānaka",
-        "value": "/towns-cities/regions/southern-lakes/locations/wanaka"
+        "value": "/towns-cities/regions/southern-lakes/locations/wanaka",
     },
-    {
-        "label": "Gore",
-        "value": "/towns-cities/regions/southland/locations/gore"
-    },
+    {"label": "Gore", "value": "/towns-cities/regions/southland/locations/gore"},
     {
         "label": "Invercargill",
-        "value": "/towns-cities/regions/southland/locations/invercargill"
+        "value": "/towns-cities/regions/southland/locations/invercargill",
     },
-    {
-        "label": "Lumsden",
-        "value": "/rural/regions/southland/locations/lumsden"
-    },
+    {"label": "Lumsden", "value": "/rural/regions/southland/locations/lumsden"},
     {
         "label": "Milford Sound",
-        "value": "/towns-cities/regions/southland/locations/milford-sound"
+        "value": "/towns-cities/regions/southland/locations/milford-sound",
     },
     {
         "label": "Stewart Island",
-        "value": "/rural/regions/southland/locations/stewart-island"
+        "value": "/rural/regions/southland/locations/stewart-island",
     },
-    {
-        "label": "Te Anau",
-        "value": "/rural/regions/southland/locations/te-anau"
-    }
+    {"label": "Te Anau", "value": "/rural/regions/southland/locations/te-anau"},
 ]
 
 
@@ -711,4 +426,3 @@ TEMPUNIT = "temperature"
 LENGTHUNIT = "length"
 SPEEDUNIT = "speed"
 PRESSUREUNIT = "pressure"
-

--- a/custom_components/metservice_weather/coordinator.py
+++ b/custom_components/metservice_weather/coordinator.py
@@ -65,7 +65,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
         self._boating_url = config.boating_url
         self._surf_url = config.surf_url
         self._unit_system_api = config.unit_system_api
-        self._base_url = 'https://www.metservice.com'
+        self._base_url = "https://www.metservice.com"
         self.unit_system = config.unit_system
         self._session = async_get_clientsession(hass)
         self.units_of_measurement = {
@@ -149,9 +149,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             await self.expand_data_urls(result_warnings)
             warnings_list = [
                 f"{warning['name']}, {warning['text']}, {warning['threatPeriod']}"
-                for warning in result_warnings.get('warnings', [])
+                for warning in result_warnings.get("warnings", [])
             ]
-            warnings_text = '\n'.join(warnings_list) if warnings_list else "No warnings"
+            warnings_text = "\n".join(warnings_list) if warnings_list else "No warnings"
             async with asyncio.timeout(10):
                 url = f"{self._api_url}{self.location}/7-days"
                 response = await self._session.get(url, headers=headers)
@@ -160,8 +160,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                     raise ValueError("No daily forecast data received.")
                 self._check_errors(url, result_daily)
             await self.expand_data_urls(result_daily)
-            result_current['weather_warnings'] = warnings_text
-            result_current['pollen'] = await self.get_pollen_data()
+            result_current["weather_warnings"] = warnings_text
+            result_current["pollen"] = await self.get_pollen_data()
             # tomorrow_* fields are derived inside normalize_public_data
             # from the 7-day data — no injection needed here.
             # Inject drying index fields by text prefix, then normalise so
@@ -179,7 +179,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             #   drying_next_good_day — "Today" when either period is usable,
             #                          day name ("Thursday") on a complete washout
             try:
-                drying_states = self.get_from_dict(result_current, ["dryingIndex", "dryingState"])
+                drying_states = self.get_from_dict(
+                    result_current, ["dryingIndex", "dryingState"]
+                )
                 if isinstance(drying_states, list):
                     drying_morning = None
                     drying_afternoon = None
@@ -191,7 +193,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                         elif text.startswith("Afternoon:"):
                             drying_afternoon = text.removeprefix("Afternoon:").strip()
                         elif text.lower().startswith("next good day"):
-                            drying_next_good_day = text.split(":", 1)[-1].strip() if ":" in text else text
+                            drying_next_good_day = (
+                                text.split(":", 1)[-1].strip() if ":" in text else text
+                            )
                         elif text:
                             # No recognised prefix — MetService uses bare "Wet all day"
                             # for the morning slot on a complete washout.
@@ -210,11 +214,11 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             except Exception as _e:
                 _LOGGER.debug("Could not extract drying index states: %s", _e)
             if self._tide_url:
-                result_current['tideImport'] = await self.get_tides()
+                result_current["tideImport"] = await self.get_tides()
             if self._boating_url:
-                result_current['boating_data'] = await self.get_boating_data()
+                result_current["boating_data"] = await self.get_boating_data()
             if self._surf_url:
-                result_current['surf_data'] = await self.get_surf_data()
+                result_current["surf_data"] = await self.get_surf_data()
             return normalize_public_data(result_current, result_daily)
 
         except ValueError as err:
@@ -232,7 +236,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                 _LOGGER.info("Fetching tides data from %s", url)
                 response = await self._session.get(url, headers=self._PUBLIC_HEADERS)
                 if response.status != 200:
-                    _LOGGER.warning("Tides endpoint returned HTTP %s — tides data will be unavailable", response.status)
+                    _LOGGER.warning(
+                        "Tides endpoint returned HTTP %s — tides data will be unavailable",
+                        response.status,
+                    )
                     return None
                 result_tides = await response.json(content_type=None)
                 if result_tides is None:
@@ -254,14 +261,21 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                             return module["tideData"]
                 except (KeyError, TypeError):
                     continue
-            _LOGGER.warning("Could not locate tideData in response — tides data will be unavailable")
+            _LOGGER.warning(
+                "Could not locate tideData in response — tides data will be unavailable"
+            )
             return None
 
         except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.warning("Error fetching tides data: %s — tides will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Error fetching tides data: %s — tides will be unavailable", repr(err)
+            )
             return None
         except Exception as err:
-            _LOGGER.warning("Unexpected error fetching tides data: %s — tides will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Unexpected error fetching tides data: %s — tides will be unavailable",
+                repr(err),
+            )
             return None
 
     async def get_boating_data(self) -> dict:
@@ -272,7 +286,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                 _LOGGER.info("Fetching boating data from %s", url)
                 response = await self._session.get(url, headers=self._PUBLIC_HEADERS)
                 if response.status != 200:
-                    _LOGGER.warning("Boating endpoint returned HTTP %s — boating data unavailable", response.status)
+                    _LOGGER.warning(
+                        "Boating endpoint returned HTTP %s — boating data unavailable",
+                        response.status,
+                    )
                     return {}
                 data = await response.json(content_type=None)
             modules = (
@@ -296,10 +313,16 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                 "boating_table": today.get("table", {}).get("columns", []),
             }
         except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.warning("Error fetching boating data: %s — boating will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Error fetching boating data: %s — boating will be unavailable",
+                repr(err),
+            )
             return {}
         except Exception as err:
-            _LOGGER.warning("Unexpected error fetching boating data: %s — boating will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Unexpected error fetching boating data: %s — boating will be unavailable",
+                repr(err),
+            )
             return {}
 
     async def get_surf_data(self) -> dict:
@@ -314,14 +337,19 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
         """
         try:
             # Derive regional surf URL from the stored location URL.
-            regional_url = re.sub(r'/locations/[^/]+$', '', self._surf_url.rstrip('/'))
+            regional_url = re.sub(r"/locations/[^/]+$", "", self._surf_url.rstrip("/"))
             location_path = self._surf_url.split("publicData/webdata")[-1]
 
             _LOGGER.info("Fetching surf data from %s", regional_url)
             async with asyncio.timeout(10):
-                response = await self._session.get(regional_url, headers=self._PUBLIC_HEADERS)
+                response = await self._session.get(
+                    regional_url, headers=self._PUBLIC_HEADERS
+                )
                 if response.status != 200:
-                    _LOGGER.warning("Surf endpoint returned HTTP %s — surf data unavailable", response.status)
+                    _LOGGER.warning(
+                        "Surf endpoint returned HTTP %s — surf data unavailable",
+                        response.status,
+                    )
                     return {}
                 data = await response.json(content_type=None)
 
@@ -342,7 +370,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                     continue
 
             if not marker:
-                _LOGGER.warning("Could not find surf marker for %s — surf data unavailable", location_path)
+                _LOGGER.warning(
+                    "Could not find surf marker for %s — surf data unavailable",
+                    location_path,
+                )
                 return {}
 
             value = marker.get("action", {}).get("modules", [{}])[0].get("value", {})
@@ -364,10 +395,15 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             }
 
         except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.warning("Error fetching surf data: %s — surf will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Error fetching surf data: %s — surf will be unavailable", repr(err)
+            )
             return {}
         except Exception as err:
-            _LOGGER.warning("Unexpected error fetching surf data: %s — surf will be unavailable", repr(err))
+            _LOGGER.warning(
+                "Unexpected error fetching surf data: %s — surf will be unavailable",
+                repr(err),
+            )
             return {}
 
     @staticmethod
@@ -376,11 +412,15 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
         level = None
         plants = None
         # Match <span class="status-...">Level</span>
-        level_match = re.search(r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>', html)
+        level_match = re.search(
+            r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>', html
+        )
         if level_match:
             level = level_match.group(1).strip()
         # Plant types appear after the closing </span> tag
-        plants_match = re.search(r'</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)', html, re.IGNORECASE)
+        plants_match = re.search(
+            r"</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)", html, re.IGNORECASE
+        )
         if plants_match:
             plants = plants_match.group(1).strip()
         return {"level": level, "type": plants}
@@ -394,7 +434,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                 _LOGGER.debug("Fetching pollen data from %s", url)
                 response = await self._session.get(url, headers=self._PUBLIC_HEADERS)
                 if response.status != 200:
-                    _LOGGER.debug("Pollen endpoint returned HTTP %s — pollen data unavailable", response.status)
+                    _LOGGER.debug(
+                        "Pollen endpoint returned HTTP %s — pollen data unavailable",
+                        response.status,
+                    )
                     return empty
                 result = await response.json(content_type=None)
             # Search all modules for the pollen iconWithText content block
@@ -453,7 +496,6 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
         """Format timestamp to ISO format in UTC."""
         return format_timestamp(timestamp_val)
 
-
     async def expand_data_urls(self, data, parent=None, key=None, _depth=0):
         """Recursively expand dataUrl entries in the data, replacing the entire object.
 
@@ -465,14 +507,18 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             _LOGGER.warning("expand_data_urls: max recursion depth reached, stopping")
             return
         if isinstance(data, dict):
-            if 'dataUrl' in data:
-                url = data['dataUrl']
-                full_url = f"{self._base_url}{url}" if url.startswith('/') else url
+            if "dataUrl" in data:
+                url = data["dataUrl"]
+                full_url = f"{self._base_url}{url}" if url.startswith("/") else url
                 try:
                     async with asyncio.timeout(10):
-                        response = await self._session.get(full_url, headers=self._PUBLIC_HEADERS)
+                        response = await self._session.get(
+                            full_url, headers=self._PUBLIC_HEADERS
+                        )
                         if response.status != 200:
-                            _LOGGER.warning("Error fetching %s: HTTP %s", full_url, response.status)
+                            _LOGGER.warning(
+                                "Error fetching %s: HTTP %s", full_url, response.status
+                            )
                             if parent is not None and key is not None:
                                 parent[key] = None
                             return
@@ -481,7 +527,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
                         parent[key] = result
                     # Increment depth only when following a dataUrl hop, not during
                     # structural traversal, so the guard catches URL expansion cycles.
-                    await self.expand_data_urls(result, parent=parent, key=key, _depth=_depth + 1)
+                    await self.expand_data_urls(
+                        result, parent=parent, key=key, _depth=_depth + 1
+                    )
                 except Exception as e:
                     _LOGGER.warning("Error fetching dataUrl %s: %s", full_url, e)
                     if parent is not None and key is not None:
@@ -489,9 +537,10 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             else:
                 for k in list(data.keys()):
                     # Pass _depth unchanged — traversing dict keys is not a URL hop.
-                    await self.expand_data_urls(data[k], parent=data, key=k, _depth=_depth)
+                    await self.expand_data_urls(
+                        data[k], parent=data, key=k, _depth=_depth
+                    )
         elif isinstance(data, list):
             for idx, item in enumerate(data):
                 # Pass _depth unchanged — traversing list items is not a URL hop.
                 await self.expand_data_urls(item, parent=data, key=idx, _depth=_depth)
-

--- a/custom_components/metservice_weather/coordinator.py
+++ b/custom_components/metservice_weather/coordinator.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 import re
 import asyncio
 
 import aiohttp
-from homeassistant.util import dt as dt_util
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -163,28 +162,8 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
             await self.expand_data_urls(result_daily)
             result_current['weather_warnings'] = warnings_text
             result_current['pollen'] = await self.get_pollen_data()
-            # Inject tomorrow's forecast from the 7-day data (day index 1).
-            # get_from_dict always returns the first match, so tomorrow's data
-            # must be explicitly extracted and injected at the root level.
-            try:
-                all_days = (
-                    result_daily.get("layout", {})
-                    .get("primary", {})
-                    .get("slots", {})
-                    .get("main", {})
-                    .get("modules", [{}])[0]
-                    .get("days", [])
-                )
-                if len(all_days) > 1:
-                    tmrw = all_days[1]
-                    tmrw_forecasts = tmrw.get("forecasts", [{}])
-                    tf = tmrw_forecasts[0] if tmrw_forecasts else {}
-                    result_current["tomorrow_condition"] = tmrw.get("condition")
-                    result_current["tomorrow_temp_high"] = tf.get("highTemp")
-                    result_current["tomorrow_temp_low"] = tf.get("lowTemp")
-                    result_current["tomorrow_description"] = tf.get("statement")
-            except Exception as _e:
-                _LOGGER.debug("Could not extract tomorrow forecast: %s", _e)
+            # tomorrow_* fields are derived inside normalize_public_data
+            # from the 7-day data — no injection needed here.
             # Inject drying index fields by text prefix, then normalise so
             # that all three sensors always carry a useful value:
             #

--- a/custom_components/metservice_weather/coordinator_types.py
+++ b/custom_components/metservice_weather/coordinator_types.py
@@ -47,6 +47,25 @@ def _find_module(modules: list, key: str) -> dict:
     return {}
 
 
+def _scan_forecasts(day: Any, key: str) -> Any:
+    """Return the first non-None `key` from forecasts entries, else the day level.
+
+    MetService publishes daily forecasts in several shapes:
+    - towns-cities: one forecasts entry carrying temps, rain probabilities
+      and the statement (temps duplicated at day level)
+    - rural: a regional-text entry (statement only) plus a location entry
+      carrying temps and rain probabilities (statement null); temps and
+      statement also appear at day level
+    Scanning every entry and then the day level covers all of them.
+    """
+    if not isinstance(day, dict):
+        return None
+    for f in day.get("forecasts") or []:
+        if isinstance(f, dict) and f.get(key) is not None:
+            return f[key]
+    return day.get(key)
+
+
 @dataclass
 class HourlyEntry:
     """Single hourly forecast entry."""
@@ -60,15 +79,21 @@ class HourlyEntry:
 
 @dataclass
 class DailyEntry:
-    """Single daily forecast entry."""
+    """Single daily forecast entry.
+
+    rain_prob_1mm / rain_prob_10mm are MetService's rainfall exceedance
+    probabilities (rainFall1 / rainFall10): the % chance of at least
+    1 mm / 10 mm of rain that day. They are probabilities, NOT amounts —
+    the public API does not publish daily rainfall amounts.
+    """
 
     datetime: str | None = None
     condition: str | None = None
     temp_high: float | None = None
     temp_low: float | None = None
     description: str | None = None
-    rainfall_low: float | None = None
-    rainfall_high: float | None = None
+    rain_prob_1mm: float | None = None
+    rain_prob_10mm: float | None = None
 
 
 @dataclass
@@ -119,12 +144,20 @@ class MetServicePublicData:
     # Derived / injected
     weather_warnings: str = "No warnings"
     tomorrow_condition: str | None = None
-    tomorrow_temp_high: str | None = None
-    tomorrow_temp_low: str | None = None
+    tomorrow_temp_high: float | None = None
+    tomorrow_temp_low: float | None = None
     tomorrow_description: str | None = None
     drying_morning: str | None = None
     drying_afternoon: str | None = None
     drying_next_good_day: str | None = None
+
+    # Capability flags — structural presence of optional page sections.
+    # Used to decide which sensor entities to create for a location.
+    # Only sections whose absence is permanent for a location belong here;
+    # seasonal products (UV, fire, drying, pollen) must stay ungated.
+    has_observations: bool = False
+    has_breakdown: bool = False
+    is_rural: bool = False
 
     # Hourly forecast
     hourly_entries: list[HourlyEntry] = field(default_factory=list)
@@ -155,23 +188,25 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
     """Build a MetServicePublicData from raw coordinator dicts.
 
     Uses exact-path traversal (_get) and explicit section extraction —
-    no DFS.  All injected fields (weather_warnings, pollen, tomorrow_*,
-    drying_*) are already present at the root of `current` when this is
-    called.
+    no DFS.  All injected fields (weather_warnings, pollen, drying_*)
+    are already present at the root of `current` when this is called;
+    tomorrow_* fields are derived here from the 7-day data.
     """
     # ------------------------------------------------------------------
     # Extract key sections from the nested layout structure
     # ------------------------------------------------------------------
 
     # Observations: layout.primary.slots.left-major.modules → module with "observations"
+    # Rural locations have no weather station: the currentConditions module
+    # expands to {} (or observations: null), so obs ends up empty.
     left_major = _get(current, "layout", "primary", "slots", "left-major", "modules") or []
-    obs = _find_module(left_major, "observations").get("observations", {})
+    obs = _find_module(left_major, "observations").get("observations") or {}
 
     # Days / breakdown / fire: layout.primary.slots.main.modules → module with "days"
     main_mods = _get(current, "layout", "primary", "slots", "main", "modules") or []
-    days = _find_module(main_mods, "days").get("days", [])
-    day0 = days[0] if days else {}
-    breakdown0 = day0.get("breakdown", {}) if isinstance(day0, dict) else {}
+    days = _find_module(main_mods, "days").get("days") or []
+    day0 = days[0] if days and isinstance(days[0], dict) else {}
+    breakdown0 = day0.get("breakdown") or {}
 
     # Hourly graph: layout.primary.slots.main.modules → module with "graph"
     graph = _find_module(main_mods, "graph").get("graph", {})
@@ -213,15 +248,18 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
         DailyEntry(
             datetime=_get(d, "date"),
             condition=_get(d, "condition"),
-            temp_high=_safe_float(_get(d, "forecasts", "0", "highTemp")),
-            temp_low=_safe_float(_get(d, "forecasts", "0", "lowTemp")),
-            description=_get(d, "forecasts", "0", "statement"),
-            rainfall_low=_safe_float(_get(d, "rainFall1")),
-            rainfall_high=_safe_float(_get(d, "rainFall10")),
+            temp_high=_safe_float(_scan_forecasts(d, "highTemp")),
+            temp_low=_safe_float(_scan_forecasts(d, "lowTemp")),
+            description=_scan_forecasts(d, "statement"),
+            rain_prob_1mm=_safe_float(_scan_forecasts(d, "rainFall1")),
+            rain_prob_10mm=_safe_float(_scan_forecasts(d, "rainFall10")),
         )
         for d in raw_days
         if isinstance(d, dict)
     ]
+
+    # Tomorrow's forecast is day index 1 of the 7-day data.
+    tomorrow = daily_entries[1] if len(daily_entries) > 1 else None
 
     # ------------------------------------------------------------------
     # Marine — boating and surf stored nested under their own keys
@@ -230,14 +268,26 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
     surf = current.get("surf_data") or {}
 
     # ------------------------------------------------------------------
+    # Today's high/low — the current-conditions widget shows day 0's
+    # forecast temps, so falling back to the forecast when there is no
+    # weather station (rural locations) yields the same quantity.
+    # ------------------------------------------------------------------
+    temp_today_high = _safe_float(_get(obs, "temperature", "0", "high"))
+    if temp_today_high is None:
+        temp_today_high = _safe_float(_scan_forecasts(day0, "highTemp"))
+    temp_today_low = _safe_float(_get(obs, "temperature", "0", "low"))
+    if temp_today_low is None:
+        temp_today_low = _safe_float(_scan_forecasts(day0, "lowTemp"))
+
+    # ------------------------------------------------------------------
     # Assemble dataclass
     # ------------------------------------------------------------------
     return MetServicePublicData(
         # Observations
         temperature=_safe_float(_get(obs, "temperature", "0", "current")),
         feels_like=_safe_float(_get(obs, "temperature", "0", "feelsLike")),
-        temp_today_high=_safe_float(_get(obs, "temperature", "0", "high")),
-        temp_today_low=_safe_float(_get(obs, "temperature", "0", "low")),
+        temp_today_high=temp_today_high,
+        temp_today_low=temp_today_low,
         humidity=_safe_int(_get(obs, "rain", "0", "relativeHumidity")),
         pressure=_safe_float(_get(obs, "pressure", "0", "atSeaLevel")),
         pressure_trend=_get(obs, "pressure", "0", "trend"),
@@ -247,9 +297,9 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
         wind_strength=_get(obs, "wind", "0", "strength"),
         rainfall=_safe_float(_get(obs, "rain", "0", "rainfall")),
         # Today's forecast (day 0)
-        condition=day0.get("condition") if isinstance(day0, dict) else None,
-        forecast_text=_get(day0, "forecasts", "0", "statement"),
-        issued_at=day0.get("issuedAt") if isinstance(day0, dict) else None,
+        condition=day0.get("condition"),
+        forecast_text=_scan_forecasts(day0, "statement"),
+        issued_at=day0.get("issuedAt"),
         uv_index=_get(uv, "sunProtection", "uvAlertLevel"),
         location_name=_get(current, "location", "label"),
         # Sub-day breakdown
@@ -272,13 +322,17 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
         pollen_type=_get(current, "pollen", "pollenLevels", "type"),
         # Injected derived fields
         weather_warnings=current.get("weather_warnings", "No warnings"),
-        tomorrow_condition=current.get("tomorrow_condition"),
-        tomorrow_temp_high=current.get("tomorrow_temp_high"),
-        tomorrow_temp_low=current.get("tomorrow_temp_low"),
-        tomorrow_description=current.get("tomorrow_description"),
+        tomorrow_condition=tomorrow.condition if tomorrow else None,
+        tomorrow_temp_high=tomorrow.temp_high if tomorrow else None,
+        tomorrow_temp_low=tomorrow.temp_low if tomorrow else None,
+        tomorrow_description=tomorrow.description if tomorrow else None,
         drying_morning=current.get("drying_morning"),
         drying_afternoon=current.get("drying_afternoon"),
         drying_next_good_day=current.get("drying_next_good_day"),
+        # Capability flags
+        has_observations=bool(obs),
+        has_breakdown=bool(breakdown0),
+        is_rural=str(day0.get("isRural", "")).lower() == "true",
         # Hourly
         hourly_entries=hourly_entries,
         hourly_obs=hourly_obs_count,

--- a/custom_components/metservice_weather/coordinator_types.py
+++ b/custom_components/metservice_weather/coordinator_types.py
@@ -1,4 +1,5 @@
 """Typed data models for the MetService coordinator."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -199,7 +200,9 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
     # Observations: layout.primary.slots.left-major.modules → module with "observations"
     # Rural locations have no weather station: the currentConditions module
     # expands to {} (or observations: null), so obs ends up empty.
-    left_major = _get(current, "layout", "primary", "slots", "left-major", "modules") or []
+    left_major = (
+        _get(current, "layout", "primary", "slots", "left-major", "modules") or []
+    )
     obs = _find_module(left_major, "observations").get("observations") or {}
 
     # Days / breakdown / fire: layout.primary.slots.main.modules → module with "days"
@@ -215,7 +218,9 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
     hourly_obs_count = graph_series[1].get("count", 0) if len(graph_series) > 1 else 0
 
     # UV: layout.primary.slots.left-minor.modules → module with "uv"
-    left_minor = _get(current, "layout", "primary", "slots", "left-minor", "modules") or []
+    left_minor = (
+        _get(current, "layout", "primary", "slots", "left-minor", "modules") or []
+    )
     uv = _find_module(left_minor, "uv").get("uv", {})
 
     # Sunrise / moon: layout.secondary.slots.major.modules → module with "riseSet"
@@ -243,7 +248,9 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
     # ------------------------------------------------------------------
     # Daily entries (from 7-day JSON)
     # ------------------------------------------------------------------
-    raw_days = _get(daily, "layout", "primary", "slots", "main", "modules", "0", "days") or []
+    raw_days = (
+        _get(daily, "layout", "primary", "slots", "main", "modules", "0", "days") or []
+    )
     daily_entries = [
         DailyEntry(
             datetime=_get(d, "date"),
@@ -315,7 +322,9 @@ def normalize_public_data(current: dict, daily: dict) -> MetServicePublicData:
         moon_phase=_get(moon_phases, "0", "phase"),
         moon_phase_date=_get(moon_phases, "0", "dateISO"),
         # Fire weather (from day 0's fireWeatherData)
-        fire_danger=_get(day0, "fireWeatherData", "fireWeather", "danger", "dailyObservation"),
+        fire_danger=_get(
+            day0, "fireWeatherData", "fireWeather", "danger", "dailyObservation"
+        ),
         fire_season=_get(day0, "fireWeatherData", "fireWeather", "season", "short"),
         # Pollen (injected at root as {"pollenLevels": {...}})
         pollen_level=_get(current, "pollen", "pollenLevels", "level"),

--- a/custom_components/metservice_weather/entity.py
+++ b/custom_components/metservice_weather/entity.py
@@ -1,4 +1,5 @@
 """Base entity for MetService weather integration."""
+
 from __future__ import annotations
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -14,6 +15,7 @@ class MetServiceEntity(CoordinatorEntity[WeatherUpdateCoordinator]):
     _attr_has_entity_name = True
 
     def __init__(self, coordinator: WeatherUpdateCoordinator) -> None:
+        """Attach the shared MetService device info to the entity."""
         super().__init__(coordinator)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.location)},

--- a/custom_components/metservice_weather/helpers.py
+++ b/custom_components/metservice_weather/helpers.py
@@ -1,4 +1,5 @@
 """Shared utility helpers for MetService weather."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -8,7 +9,11 @@ from homeassistant.util import dt as dt_util
 
 def format_timestamp(timestamp_val: str) -> str:
     """Format an ISO timestamp string to UTC ISO format."""
-    return datetime.fromisoformat(timestamp_val).astimezone(dt_util.get_time_zone("UTC")).isoformat()
+    return (
+        datetime.fromisoformat(timestamp_val)
+        .astimezone(dt_util.get_time_zone("UTC"))
+        .isoformat()
+    )
 
 
 def safe_float(value: object) -> float | None:

--- a/custom_components/metservice_weather/manifest.json
+++ b/custom_components/metservice_weather/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/nagelm/metservice-weather/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "2026.7.0"
 }

--- a/custom_components/metservice_weather/manifest.json
+++ b/custom_components/metservice_weather/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/nagelm/metservice-weather/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -3,6 +3,7 @@
 For more details about this platform, please refer to the documentation at
 https://github.com/ciejer/metservice-weather.
 """
+
 from __future__ import annotations
 
 import logging
@@ -30,13 +31,15 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-SENSOR_DESCRIPTIONS: tuple[
-    WeatherSensorEntityDescription, ...
-] = current_condition_sensor_descriptions_public
+SENSOR_DESCRIPTIONS: tuple[WeatherSensorEntityDescription, ...] = (
+    current_condition_sensor_descriptions_public
+)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry[WeatherUpdateCoordinator], async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry[WeatherUpdateCoordinator],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add MetService entities from a config_entry.
 
@@ -56,7 +59,10 @@ async def async_setup_entry(
     ent_reg = er.async_get(hass)
     expected_unique_ids = {sensor.unique_id for sensor in sensors}
     for reg_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
-        if reg_entry.domain == SENSOR_DOMAIN and reg_entry.unique_id not in expected_unique_ids:
+        if (
+            reg_entry.domain == SENSOR_DOMAIN
+            and reg_entry.unique_id not in expected_unique_ids
+        ):
             ent_reg.async_remove(reg_entry.entity_id)
 
     async_add_entities(sensors)
@@ -77,9 +83,7 @@ class WeatherSensor(MetServiceEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
 
-        self._attr_unique_id = (
-            f"{self.coordinator.location}_{description.key}".lower()
-        )
+        self._attr_unique_id = f"{self.coordinator.location}_{description.key}".lower()
         self._unit_system = coordinator.unit_system
         self._sensor_data = coordinator.data
         self._attr_native_unit_of_measurement = self.entity_description.unit_fn(
@@ -93,7 +97,9 @@ class WeatherSensor(MetServiceEntity, SensorEntity):
             _LOGGER.debug("Sensor '%s' has no data.", self.name)
             return None
         try:
-            return self.entity_description.value_fn(self._sensor_data, self._unit_system)
+            return self.entity_description.value_fn(
+                self._sensor_data, self._unit_system
+            )
         except Exception as e:
             _LOGGER.error("Error processing state for sensor '%s': %s", self.name, e)
             return None
@@ -106,9 +112,10 @@ class WeatherSensor(MetServiceEntity, SensorEntity):
         try:
             return self.entity_description.attr_fn(self._sensor_data)
         except Exception as e:
-            _LOGGER.error("Error processing attributes for sensor '%s': %s", self.name, e)
+            _LOGGER.error(
+                "Error processing attributes for sensor '%s': %s", self.name, e
+            )
             return {}
-
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_system import METRIC_SYSTEM
@@ -37,28 +38,27 @@ SENSOR_DESCRIPTIONS: tuple[
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry[WeatherUpdateCoordinator], async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Add MetService entities from a config_entry."""
+    """Add MetService entities from a config_entry.
+
+    Each description's exists_fn decides whether the configured location
+    supports that sensor (marine sensors need a configured marine location;
+    observation sensors need a weather station, which rural locations lack).
+    Registry entries for sensors the location no longer provides are removed
+    so users aren't left with permanently-unknown entities.
+    """
     coordinator: WeatherUpdateCoordinator = entry.runtime_data
-    descriptions = list(SENSOR_DESCRIPTIONS)
+    sensors = [
+        WeatherSensor(coordinator, description)
+        for description in SENSOR_DESCRIPTIONS
+        if description.exists_fn(coordinator)
+    ]
 
-    # Skip tide sensors when no tide location is configured
-    if not coordinator.enable_tides:
-        descriptions = [d for d in descriptions if d.key not in ("tides_high", "tides_low")]
+    ent_reg = er.async_get(hass)
+    expected_unique_ids = {sensor.unique_id for sensor in sensors}
+    for reg_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if reg_entry.domain == SENSOR_DOMAIN and reg_entry.unique_id not in expected_unique_ids:
+            ent_reg.async_remove(reg_entry.entity_id)
 
-    # Skip boating sensors when no boating location is configured
-    if not coordinator.enable_boating:
-        descriptions = [d for d in descriptions if d.key not in ("boating_status", "boating_forecast")]
-
-    # Skip surf sensors when no surf location is configured
-    _SURF_KEYS = {
-        "surf_conditions", "surf_rating", "surf_wave_height", "surf_set_face",
-        "surf_swell_direction", "surf_swell_height", "surf_wind_direction",
-        "surf_wind_speed", "surf_wind_gust", "surf_period",
-    }
-    if not coordinator.enable_surf:
-        descriptions = [d for d in descriptions if d.key not in _SURF_KEYS]
-
-    sensors = [WeatherSensor(coordinator, description) for description in descriptions]
     async_add_entities(sensors)
 
 

--- a/custom_components/metservice_weather/weather.py
+++ b/custom_components/metservice_weather/weather.py
@@ -61,9 +61,10 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
     """Implementation of a MetService weather service."""
 
     @property
-    def native_temperature(self) -> float:
+    def native_temperature(self) -> float | None:
         """Return the platform temperature in native units (i.e. not converted)."""
-        return self.coordinator.data.temperature
+        data = self.coordinator.data
+        return data.temperature if data else None
 
     @property
     def native_temperature_unit(self) -> str:
@@ -71,9 +72,10 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
         return self.coordinator.units_of_measurement[TEMPUNIT]
 
     @property
-    def native_pressure(self) -> float:
+    def native_pressure(self) -> float | None:
         """Return the pressure in native units."""
-        return self.coordinator.data.pressure
+        data = self.coordinator.data
+        return data.pressure if data else None
 
     @property
     def native_pressure_unit(self) -> str:
@@ -83,12 +85,14 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
     @property
     def humidity(self) -> int | None:
         """Return the relative humidity in native units."""
-        return self.coordinator.data.humidity
+        data = self.coordinator.data
+        return data.humidity if data else None
 
     @property
-    def native_wind_speed(self) -> float:
+    def native_wind_speed(self) -> float | None:
         """Return the wind speed in native units."""
-        return self.coordinator.data.wind_speed
+        data = self.coordinator.data
+        return data.wind_speed if data else None
 
     @property
     def native_wind_speed_unit(self) -> str:
@@ -96,9 +100,10 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
         return self.coordinator.units_of_measurement[SPEEDUNIT]
 
     @property
-    def wind_bearing(self) -> str:
+    def wind_bearing(self) -> str | None:
         """Return the wind bearing."""
-        return self.coordinator.data.wind_direction
+        data = self.coordinator.data
+        return data.wind_direction if data else None
 
     @property
     def native_precipitation_unit(self) -> str:
@@ -106,9 +111,12 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
         return self.coordinator.units_of_measurement[LENGTHUNIT]
 
     @property
-    def condition(self) -> str:
+    def condition(self) -> str | None:
         """Return the current condition."""
-        raw = self.coordinator.data.condition
+        data = self.coordinator.data
+        if data is None:
+            return None
+        raw = data.condition
         mapped = CONDITION_MAP.get(raw, raw)
         if mapped == "sunny" and not sun_helper.is_up(self.hass):
             return "clear-night"
@@ -155,6 +163,8 @@ class MetServiceForecastPublic(MetServicePublic):
 
         forecast = []
         data = self.coordinator.data
+        if data is None:
+            return forecast
         hourly_entries = data.hourly_entries
         hourly_obs = data.hourly_obs
         hourly_skip = data.hourly_skip
@@ -199,7 +209,10 @@ class MetServiceForecastPublic(MetServicePublic):
         """Return the daily forecast in native units."""
 
         forecast = []
-        for day in self.coordinator.data.daily_entries:
+        data = self.coordinator.data
+        if data is None:
+            return forecast
+        for day in data.daily_entries:
             day_condition = day.condition
             if day_condition in CONDITION_MAP:
                 day_condition = CONDITION_MAP[day_condition]

--- a/custom_components/metservice_weather/weather.py
+++ b/custom_components/metservice_weather/weather.py
@@ -24,6 +24,7 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_NATIVE_TEMP,
     ATTR_FORECAST_NATIVE_TEMP_LOW,
     ATTR_FORECAST_NATIVE_WIND_SPEED,
+    ATTR_FORECAST_PRECIPITATION_PROBABILITY,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_BEARING,
     ATTR_FORECAST_CONDITION,
@@ -38,12 +39,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import sun as sun_helper
 
+from .helpers import format_timestamp
+
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-
-from .helpers import format_timestamp
 
 
 async def async_setup_entry(
@@ -204,16 +204,19 @@ class MetServiceForecastPublic(MetServicePublic):
                 forecast_time = format_timestamp(day.datetime) if day.datetime else None
             except (ValueError, AttributeError):
                 forecast_time = day.datetime
-            forecast.append(
-                Forecast(
-                    {
-                        ATTR_FORECAST_NATIVE_TEMP: day.temp_high,
-                        ATTR_FORECAST_NATIVE_TEMP_LOW: day.temp_low,
-                        ATTR_FORECAST_CONDITION: day_condition,
-                        ATTR_FORECAST_TIME: forecast_time,
-                        ATTR_FORECAST_NATIVE_PRECIPITATION: day.rainfall_low,
-                    }
-                )
+            entry = Forecast(
+                {
+                    ATTR_FORECAST_NATIVE_TEMP: day.temp_high,
+                    ATTR_FORECAST_NATIVE_TEMP_LOW: day.temp_low,
+                    ATTR_FORECAST_CONDITION: day_condition,
+                    ATTR_FORECAST_TIME: forecast_time,
+                }
             )
+            # MetService publishes the % chance of ≥1 mm of rain
+            # (an exceedance probability), not a rainfall amount, so it
+            # maps to precipitation_probability — never to precipitation.
+            if day.rain_prob_1mm is not None:
+                entry[ATTR_FORECAST_PRECIPITATION_PROBABILITY] = round(day.rain_prob_1mm)
+            forecast.append(entry)
         return forecast
 

--- a/custom_components/metservice_weather/weather.py
+++ b/custom_components/metservice_weather/weather.py
@@ -3,6 +3,7 @@
 For more details about this platform, please refer to the documentation at
 https://github.com/ciejer/metservice-weather.
 """
+
 from __future__ import annotations
 
 from .coordinator import WeatherUpdateCoordinator
@@ -47,7 +48,9 @@ PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry[WeatherUpdateCoordinator], async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry[WeatherUpdateCoordinator],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add weather entity."""
     coordinator: WeatherUpdateCoordinator = entry.runtime_data
@@ -115,7 +118,9 @@ class MetServicePublic(MetServiceEntity, SingleCoordinatorWeatherEntity):
 class MetServiceForecastPublic(MetServicePublic):
     """Implementation of a MetService weather forecast."""
 
-    _attr_supported_features = WeatherEntityFeature.FORECAST_HOURLY | WeatherEntityFeature.FORECAST_DAILY
+    _attr_supported_features = (
+        WeatherEntityFeature.FORECAST_HOURLY | WeatherEntityFeature.FORECAST_DAILY
+    )
 
     def __init__(self, coordinator: WeatherUpdateCoordinator):
         """Initialize the forecast sensor."""
@@ -157,7 +162,7 @@ class MetServiceForecastPublic(MetServicePublic):
         if not hourly_entries or hourly_obs is None or hourly_skip is None:
             return forecast
 
-        for entry in hourly_entries[hourly_skip:hourly_obs + hourly_skip]:
+        for entry in hourly_entries[hourly_skip : hourly_obs + hourly_skip]:
             rainfall = entry.rainfall
             wind_speed = entry.wind_speed
             wind_dir = entry.wind_direction
@@ -179,9 +184,7 @@ class MetServiceForecastPublic(MetServicePublic):
                 Forecast(
                     {
                         ATTR_FORECAST_NATIVE_TEMP: entry.temperature,
-                        ATTR_FORECAST_TIME: format_timestamp(
-                            entry.datetime
-                        ),
+                        ATTR_FORECAST_TIME: format_timestamp(entry.datetime),
                         ATTR_FORECAST_NATIVE_PRECIPITATION: rainfall,
                         ATTR_FORECAST_NATIVE_WIND_SPEED: wind_speed,
                         ATTR_FORECAST_WIND_BEARING: wind_dir,
@@ -216,7 +219,8 @@ class MetServiceForecastPublic(MetServicePublic):
             # (an exceedance probability), not a rainfall amount, so it
             # maps to precipitation_probability — never to precipitation.
             if day.rain_prob_1mm is not None:
-                entry[ATTR_FORECAST_PRECIPITATION_PROBABILITY] = round(day.rain_prob_1mm)
+                entry[ATTR_FORECAST_PRECIPITATION_PROBABILITY] = round(
+                    day.rain_prob_1mm
+                )
             forecast.append(entry)
         return forecast
-

--- a/custom_components/metservice_weather/weather_current_conditions_sensors.py
+++ b/custom_components/metservice_weather/weather_current_conditions_sensors.py
@@ -41,7 +41,6 @@ _MOON_PHASE_NAMES: dict[str, str] = {
 }
 
 
-
 def _next_tide_time(data: list | None, tide_type: str) -> datetime.datetime | None:
     """Return the next upcoming tide of the given type, or None if unavailable."""
     if not isinstance(data, list):
@@ -53,6 +52,7 @@ def _next_tide_time(data: list | None, tide_type: str) -> datetime.datetime | No
             if t is not None and t > now:
                 return t
     return None
+
 
 def _has_observations(coordinator: Any) -> bool:
     """Location has a weather station (rural pages have none)."""
@@ -87,7 +87,9 @@ class WeatherRequiredKeysMixin:
 class WeatherSensorEntityDescription(SensorEntityDescription, WeatherRequiredKeysMixin):
     """Describes MetService Sensor entity."""
 
-    attr_fn: Callable[[dict[str, Any]], dict[str, StateType]] = field(default=lambda _: {})
+    attr_fn: Callable[[dict[str, Any]], dict[str, StateType]] = field(
+        default=lambda _: {}
+    )
     unit_fn: Callable[[bool], str | None] = field(default=lambda _: None)
     # Receives the WeatherUpdateCoordinator; return False to skip creating
     # this entity for the configured location.
@@ -100,9 +102,11 @@ current_condition_sensor_descriptions_public = [
         translation_key="valid_time_local",
         name="Forecast Description Updated Time",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data, _: datetime.datetime.fromisoformat(data.issued_at)
-        if isinstance(data.issued_at, str)
-        else None,
+        value_fn=lambda data, _: (
+            datetime.datetime.fromisoformat(data.issued_at)
+            if isinstance(data.issued_at, str)
+            else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key=FIELD_DESCRIPTION,
@@ -113,9 +117,11 @@ current_condition_sensor_descriptions_public = [
             if isinstance(data.forecast_text, str) and len(data.forecast_text) > 255
             else (data.forecast_text or "No description")
         ),
-        attr_fn=lambda data: {"full_description": data.forecast_text}
-        if isinstance(data.forecast_text, str) and data.forecast_text
-        else {},
+        attr_fn=lambda data: (
+            {"full_description": data.forecast_text}
+            if isinstance(data.forecast_text, str) and data.forecast_text
+            else {}
+        ),
     ),
     WeatherSensorEntityDescription(
         key=FIELD_HUMIDITY,
@@ -151,9 +157,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS
-        if metric
-        else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.feels_like),
     ),
     WeatherSensorEntityDescription(
@@ -164,9 +170,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS
-        if metric
-        else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.temperature),
     ),
     WeatherSensorEntityDescription(
@@ -188,9 +194,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfSpeed.KILOMETERS_PER_HOUR
-        if metric
-        else UnitOfSpeed.MILES_PER_HOUR,
+        unit_fn=lambda metric: (
+            UnitOfSpeed.KILOMETERS_PER_HOUR if metric else UnitOfSpeed.MILES_PER_HOUR
+        ),
         value_fn=lambda data, _: _safe_float(data.wind_gust),
     ),
     WeatherSensorEntityDescription(
@@ -201,9 +207,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfSpeed.KILOMETERS_PER_HOUR
-        if metric
-        else UnitOfSpeed.MILES_PER_HOUR,
+        unit_fn=lambda metric: (
+            UnitOfSpeed.KILOMETERS_PER_HOUR if metric else UnitOfSpeed.MILES_PER_HOUR
+        ),
         value_fn=lambda data, _: _safe_float(data.wind_speed),
     ),
     WeatherSensorEntityDescription(
@@ -234,15 +240,17 @@ current_condition_sensor_descriptions_public = [
         key="pollen_type",
         translation_key="pollen_type",
         name="Pollen Type",
-        value_fn=lambda data, _: cast(
-            str,
-            ". ".join(
-                i.capitalize()
-                for i in data.pollen_type.lstrip(" ")[0:254].split(". ")
-            ),
-        )
-        if data.pollen_type
-        else None,
+        value_fn=lambda data, _: (
+            cast(
+                str,
+                ". ".join(
+                    i.capitalize()
+                    for i in data.pollen_type.lstrip(" ")[0:254].split(". ")
+                ),
+            )
+            if data.pollen_type
+            else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="weather_warnings",
@@ -271,19 +279,25 @@ current_condition_sensor_descriptions_public = [
         key="drying_index_morning",
         translation_key="drying_index_morning",
         name="Clothes Drying Time - Morning",
-        value_fn=lambda data, _: cast(str, data.drying_morning) if data.drying_morning else None,
+        value_fn=lambda data, _: (
+            cast(str, data.drying_morning) if data.drying_morning else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="drying_index_afternoon",
         translation_key="drying_index_afternoon",
         name="Clothes Drying Time - Afternoon",
-        value_fn=lambda data, _: cast(str, data.drying_afternoon) if data.drying_afternoon else None,
+        value_fn=lambda data, _: (
+            cast(str, data.drying_afternoon) if data.drying_afternoon else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="drying_next_good_day",
         translation_key="drying_next_good_day",
         name="Clothes Drying - Next Good Day",
-        value_fn=lambda data, _: cast(str, data.drying_next_good_day) if data.drying_next_good_day else None,
+        value_fn=lambda data, _: (
+            cast(str, data.drying_next_good_day) if data.drying_next_good_day else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="tides_high",
@@ -306,7 +320,9 @@ current_condition_sensor_descriptions_public = [
         translation_key="boating_status",
         name="Boating Conditions",
         exists_fn=_boating_enabled,
-        value_fn=lambda data, _: cast(str, data.boating_status) if data.boating_status else None,
+        value_fn=lambda data, _: (
+            cast(str, data.boating_status) if data.boating_status else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="boating_forecast",
@@ -315,7 +331,8 @@ current_condition_sensor_descriptions_public = [
         exists_fn=_boating_enabled,
         value_fn=lambda data, _: (
             f"{data.boating_forecast[:252]}..."
-            if isinstance(data.boating_forecast, str) and len(data.boating_forecast) > 255
+            if isinstance(data.boating_forecast, str)
+            and len(data.boating_forecast) > 255
             else (data.boating_forecast or None)
         ),
     ),
@@ -325,7 +342,9 @@ current_condition_sensor_descriptions_public = [
         translation_key="surf_conditions",
         name="Surf Conditions",
         exists_fn=_surf_enabled,
-        value_fn=lambda data, _: cast(str, data.surf_conditions) if data.surf_conditions else None,
+        value_fn=lambda data, _: (
+            cast(str, data.surf_conditions) if data.surf_conditions else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="surf_rating",
@@ -363,7 +382,9 @@ current_condition_sensor_descriptions_public = [
         translation_key="surf_swell_direction",
         name="Surf Swell Direction",
         exists_fn=_surf_enabled,
-        value_fn=lambda data, _: cast(str, data.surf_swell_direction) if data.surf_swell_direction else None,
+        value_fn=lambda data, _: (
+            cast(str, data.surf_swell_direction) if data.surf_swell_direction else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="surf_swell_height",
@@ -381,7 +402,9 @@ current_condition_sensor_descriptions_public = [
         translation_key="surf_wind_direction",
         name="Surf Wind Direction",
         exists_fn=_surf_enabled,
-        value_fn=lambda data, _: cast(str, data.surf_wind_direction) if data.surf_wind_direction else None,
+        value_fn=lambda data, _: (
+            cast(str, data.surf_wind_direction) if data.surf_wind_direction else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="surf_wind_speed",
@@ -421,7 +444,9 @@ current_condition_sensor_descriptions_public = [
         translation_key="wind_strength",
         name="Wind Strength",
         exists_fn=_has_observations,
-        value_fn=lambda data, _: cast(str, data.wind_strength) if data.wind_strength else None,
+        value_fn=lambda data, _: (
+            cast(str, data.wind_strength) if data.wind_strength else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="temperature_today_high",
@@ -430,7 +455,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.temp_today_high),
     ),
     WeatherSensorEntityDescription(
@@ -440,7 +467,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.temp_today_low),
     ),
     # --- Tomorrow's forecast (injected from 7-day data) ---
@@ -448,7 +477,9 @@ current_condition_sensor_descriptions_public = [
         key="tomorrow_condition",
         translation_key="tomorrow_condition",
         name="Tomorrow — Condition",
-        value_fn=lambda data, _: cast(str, data.tomorrow_condition) if data.tomorrow_condition else None,
+        value_fn=lambda data, _: (
+            cast(str, data.tomorrow_condition) if data.tomorrow_condition else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="tomorrow_temp_high",
@@ -457,7 +488,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.tomorrow_temp_high),
     ),
     WeatherSensorEntityDescription(
@@ -467,7 +500,9 @@ current_condition_sensor_descriptions_public = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
-        unit_fn=lambda metric: UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT,
+        unit_fn=lambda metric: (
+            UnitOfTemperature.CELSIUS if metric else UnitOfTemperature.FAHRENHEIT
+        ),
         value_fn=lambda data, _: _safe_float(data.tomorrow_temp_low),
     ),
     WeatherSensorEntityDescription(
@@ -476,7 +511,8 @@ current_condition_sensor_descriptions_public = [
         name="Tomorrow — Description",
         value_fn=lambda data, _: (
             f"{data.tomorrow_description[:252]}..."
-            if isinstance(data.tomorrow_description, str) and len(data.tomorrow_description) > 255
+            if isinstance(data.tomorrow_description, str)
+            and len(data.tomorrow_description) > 255
             else (data.tomorrow_description or None)
         ),
     ),
@@ -486,28 +522,36 @@ current_condition_sensor_descriptions_public = [
         translation_key="breakdown_morning",
         name="Today — Morning Condition",
         exists_fn=_has_breakdown,
-        value_fn=lambda data, _: cast(str, data.breakdown_morning) if data.breakdown_morning else None,
+        value_fn=lambda data, _: (
+            cast(str, data.breakdown_morning) if data.breakdown_morning else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="breakdown_afternoon",
         translation_key="breakdown_afternoon",
         name="Today — Afternoon Condition",
         exists_fn=_has_breakdown,
-        value_fn=lambda data, _: cast(str, data.breakdown_afternoon) if data.breakdown_afternoon else None,
+        value_fn=lambda data, _: (
+            cast(str, data.breakdown_afternoon) if data.breakdown_afternoon else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="breakdown_evening",
         translation_key="breakdown_evening",
         name="Today — Evening Condition",
         exists_fn=_has_breakdown,
-        value_fn=lambda data, _: cast(str, data.breakdown_evening) if data.breakdown_evening else None,
+        value_fn=lambda data, _: (
+            cast(str, data.breakdown_evening) if data.breakdown_evening else None
+        ),
     ),
     WeatherSensorEntityDescription(
         key="breakdown_overnight",
         translation_key="breakdown_overnight",
         name="Today — Overnight Condition",
         exists_fn=_has_breakdown,
-        value_fn=lambda data, _: cast(str, data.breakdown_overnight) if data.breakdown_overnight else None,
+        value_fn=lambda data, _: (
+            cast(str, data.breakdown_overnight) if data.breakdown_overnight else None
+        ),
     ),
     # --- Sun and moon (from sunAndMoon module) ---
     WeatherSensorEntityDescription(
@@ -538,9 +582,13 @@ current_condition_sensor_descriptions_public = [
         key="moon_phase",
         translation_key="moon_phase",
         name="Moon Phase",
-        value_fn=lambda data, _: _MOON_PHASE_NAMES.get(cast(str, data.moon_phase), cast(str, data.moon_phase))
-        if data.moon_phase
-        else None,
+        value_fn=lambda data, _: (
+            _MOON_PHASE_NAMES.get(
+                cast(str, data.moon_phase), cast(str, data.moon_phase)
+            )
+            if data.moon_phase
+            else None
+        ),
         attr_fn=lambda data: {"raw_phase": data.moon_phase} if data.moon_phase else {},
     ),
     WeatherSensorEntityDescription(
@@ -548,9 +596,10 @@ current_condition_sensor_descriptions_public = [
         translation_key="moon_phase_date",
         name="Next Moon Phase Date",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda data, _: datetime.datetime.fromisoformat(data.moon_phase_date)
-        if isinstance(data.moon_phase_date, str)
-        else None,
+        value_fn=lambda data, _: (
+            datetime.datetime.fromisoformat(data.moon_phase_date)
+            if isinstance(data.moon_phase_date, str)
+            else None
+        ),
     ),
 ]
-

--- a/custom_components/metservice_weather/weather_current_conditions_sensors.py
+++ b/custom_components/metservice_weather/weather_current_conditions_sensors.py
@@ -54,6 +54,28 @@ def _next_tide_time(data: list | None, tide_type: str) -> datetime.datetime | No
                 return t
     return None
 
+def _has_observations(coordinator: Any) -> bool:
+    """Location has a weather station (rural pages have none)."""
+    return coordinator.data is not None and coordinator.data.has_observations
+
+
+def _has_breakdown(coordinator: Any) -> bool:
+    """Location's forecast carries morning/afternoon/evening/overnight conditions."""
+    return coordinator.data is not None and coordinator.data.has_breakdown
+
+
+def _tides_enabled(coordinator: Any) -> bool:
+    return coordinator.enable_tides
+
+
+def _boating_enabled(coordinator: Any) -> bool:
+    return coordinator.enable_boating
+
+
+def _surf_enabled(coordinator: Any) -> bool:
+    return coordinator.enable_surf
+
+
 @dataclass(frozen=True, kw_only=True)
 class WeatherRequiredKeysMixin:
     """Mixin for required keys."""
@@ -67,6 +89,9 @@ class WeatherSensorEntityDescription(SensorEntityDescription, WeatherRequiredKey
 
     attr_fn: Callable[[dict[str, Any]], dict[str, StateType]] = field(default=lambda _: {})
     unit_fn: Callable[[bool], str | None] = field(default=lambda _: None)
+    # Receives the WeatherUpdateCoordinator; return False to skip creating
+    # this entity for the configured location.
+    exists_fn: Callable[[Any], bool] = field(default=lambda _: True)
 
 
 current_condition_sensor_descriptions_public = [
@@ -96,6 +121,7 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_HUMIDITY,
         translation_key="relative_humidity",
         name="Relative Humidity",
+        exists_fn=_has_observations,
         device_class=SensorDeviceClass.HUMIDITY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
@@ -114,12 +140,14 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_WINDDIR,
         translation_key="wind_direction",
         name="Wind Direction",
+        exists_fn=_has_observations,
         value_fn=lambda data, _: cast(str, data.wind_direction),
     ),
     WeatherSensorEntityDescription(
         key="temperatureFeelsLike",
         translation_key="temperature_feels_like",
         name="Temperature - Feels Like",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
@@ -132,6 +160,7 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_TEMP,
         translation_key="temperature",
         name="Temperature",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
@@ -144,6 +173,7 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_PRESSURE,
         translation_key="pressure",
         name="Pressure",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.PRESSURE,
         suggested_display_precision=1,
@@ -154,6 +184,7 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_WINDGUST,
         translation_key="wind_gust",
         name="Wind Gust",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=1,
@@ -166,6 +197,7 @@ current_condition_sensor_descriptions_public = [
         key=FIELD_WINDSPEED,
         translation_key="wind_speed",
         name="Wind Speed",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=1,
@@ -178,6 +210,7 @@ current_condition_sensor_descriptions_public = [
         key="rainfall",
         translation_key="rainfall",
         name="Rainfall",
+        exists_fn=_has_observations,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.PRECIPITATION,
         suggested_display_precision=1,
@@ -188,6 +221,7 @@ current_condition_sensor_descriptions_public = [
         key="pressureTendencyTrend",
         translation_key="pressure_tendency_trend",
         name="Pressure Tendency Trend",
+        exists_fn=_has_observations,
         value_fn=lambda data, _: cast(str, data.pressure_trend),
     ),
     WeatherSensorEntityDescription(
@@ -255,6 +289,7 @@ current_condition_sensor_descriptions_public = [
         key="tides_high",
         translation_key="tides_high",
         name="Next High Tide",
+        exists_fn=_tides_enabled,
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data, _: _next_tide_time(data.tides, "HIGH"),
     ),
@@ -262,6 +297,7 @@ current_condition_sensor_descriptions_public = [
         key="tides_low",
         translation_key="tides_low",
         name="Next Low Tide",
+        exists_fn=_tides_enabled,
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda data, _: _next_tide_time(data.tides, "LOW"),
     ),
@@ -269,12 +305,14 @@ current_condition_sensor_descriptions_public = [
         key="boating_status",
         translation_key="boating_status",
         name="Boating Conditions",
+        exists_fn=_boating_enabled,
         value_fn=lambda data, _: cast(str, data.boating_status) if data.boating_status else None,
     ),
     WeatherSensorEntityDescription(
         key="boating_forecast",
         translation_key="boating_forecast",
         name="Boating Forecast",
+        exists_fn=_boating_enabled,
         value_fn=lambda data, _: (
             f"{data.boating_forecast[:252]}..."
             if isinstance(data.boating_forecast, str) and len(data.boating_forecast) > 255
@@ -286,12 +324,14 @@ current_condition_sensor_descriptions_public = [
         key="surf_conditions",
         translation_key="surf_conditions",
         name="Surf Conditions",
+        exists_fn=_surf_enabled,
         value_fn=lambda data, _: cast(str, data.surf_conditions) if data.surf_conditions else None,
     ),
     WeatherSensorEntityDescription(
         key="surf_rating",
         translation_key="surf_rating",
         name="Surf Rating",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         value_fn=lambda data, _: _safe_int(data.surf_rating),
@@ -300,6 +340,7 @@ current_condition_sensor_descriptions_public = [
         key="surf_wave_height",
         translation_key="surf_wave_height",
         name="Surf Wave Height",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
         suggested_display_precision=1,
@@ -310,6 +351,7 @@ current_condition_sensor_descriptions_public = [
         key="surf_set_face",
         translation_key="surf_set_face",
         name="Surf Set Face",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
         suggested_display_precision=1,
@@ -320,12 +362,14 @@ current_condition_sensor_descriptions_public = [
         key="surf_swell_direction",
         translation_key="surf_swell_direction",
         name="Surf Swell Direction",
+        exists_fn=_surf_enabled,
         value_fn=lambda data, _: cast(str, data.surf_swell_direction) if data.surf_swell_direction else None,
     ),
     WeatherSensorEntityDescription(
         key="surf_swell_height",
         translation_key="surf_swell_height",
         name="Surf Swell Height",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DISTANCE,
         suggested_display_precision=1,
@@ -336,12 +380,14 @@ current_condition_sensor_descriptions_public = [
         key="surf_wind_direction",
         translation_key="surf_wind_direction",
         name="Surf Wind Direction",
+        exists_fn=_surf_enabled,
         value_fn=lambda data, _: cast(str, data.surf_wind_direction) if data.surf_wind_direction else None,
     ),
     WeatherSensorEntityDescription(
         key="surf_wind_speed",
         translation_key="surf_wind_speed",
         name="Surf Wind Speed",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=0,
@@ -352,6 +398,7 @@ current_condition_sensor_descriptions_public = [
         key="surf_wind_gust",
         translation_key="surf_wind_gust",
         name="Surf Wind Gust",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_SPEED,
         suggested_display_precision=0,
@@ -362,6 +409,7 @@ current_condition_sensor_descriptions_public = [
         key="surf_period",
         translation_key="surf_period",
         name="Surf Period",
+        exists_fn=_surf_enabled,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         unit_fn=lambda _: "s",
@@ -372,6 +420,7 @@ current_condition_sensor_descriptions_public = [
         key="wind_strength",
         translation_key="wind_strength",
         name="Wind Strength",
+        exists_fn=_has_observations,
         value_fn=lambda data, _: cast(str, data.wind_strength) if data.wind_strength else None,
     ),
     WeatherSensorEntityDescription(
@@ -436,24 +485,28 @@ current_condition_sensor_descriptions_public = [
         key="breakdown_morning",
         translation_key="breakdown_morning",
         name="Today — Morning Condition",
+        exists_fn=_has_breakdown,
         value_fn=lambda data, _: cast(str, data.breakdown_morning) if data.breakdown_morning else None,
     ),
     WeatherSensorEntityDescription(
         key="breakdown_afternoon",
         translation_key="breakdown_afternoon",
         name="Today — Afternoon Condition",
+        exists_fn=_has_breakdown,
         value_fn=lambda data, _: cast(str, data.breakdown_afternoon) if data.breakdown_afternoon else None,
     ),
     WeatherSensorEntityDescription(
         key="breakdown_evening",
         translation_key="breakdown_evening",
         name="Today — Evening Condition",
+        exists_fn=_has_breakdown,
         value_fn=lambda data, _: cast(str, data.breakdown_evening) if data.breakdown_evening else None,
     ),
     WeatherSensorEntityDescription(
         key="breakdown_overnight",
         translation_key="breakdown_overnight",
         name="Today — Overnight Condition",
+        exists_fn=_has_breakdown,
         value_fn=lambda data, _: cast(str, data.breakdown_overnight) if data.breakdown_overnight else None,
     ),
     # --- Sun and moon (from sunAndMoon module) ---

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,37 @@
 
 ---
 
+## v1.1.0
+
+### Rural locations fixed, correct rain probabilities
+
+Fixes [#2](https://github.com/nagelm/metservice-weather/issues/2) and [#3](https://github.com/nagelm/metservice-weather/issues/3); delivers the rural-town half of [#4](https://github.com/nagelm/metservice-weather/issues/4).
+
+#### Rain "amounts" were actually probabilities (#3)
+
+MetService's daily `rainFall1`/`rainFall10` fields are **exceedance probabilities** — the % chance of at least 1 mm / 10 mm of rain that day — not rainfall amounts. Earlier releases reported them as `precipitation` in mm (so "95% chance of ≥1 mm" showed as 95 mm of rain, and "low" always looked bigger than "high").
+
+- The daily forecast now exposes `precipitation_probability` (the ≥1 mm probability, matching the "chance of rain" shown on metservice.com) and no longer reports a daily precipitation amount — the public API doesn't publish one.
+- The `precipitation_low_mm` / `precipitation_high_mm` attributes from v0.9.x are gone. If you templated against them, switch to `precipitation_probability`.
+- Hourly forecast precipitation is unchanged — that is real mm data.
+
+#### Rural locations now fully work (#2, #4)
+
+~80 of the selectable locations are MetService *rural* pages, which have a different data shape (no weather station, temps and rain probabilities nested differently, regional + local forecast text). Previously these locations showed `Unknown` for many sensors and, since v1.0.0, missing daily temps. Now:
+
+- Daily forecast: high/low temps, condition, chance of rain, and the regional multi-day text descriptions all populate.
+- Today's / Tomorrow's high & low temperature sensors work (today's falls back to the day-0 forecast — the same value MetService shows — when there is no station).
+- Sensors a location can never provide (wind/temperature/pressure/humidity observations, morning/afternoon/evening/overnight breakdowns) are no longer created as permanently-unknown entities, and stale ones are cleaned from the entity registry on upgrade.
+- Seasonal sensors (UV, fire danger, clothes drying, pollen) are still created everywhere and read `unknown` off-season — that's MetService pausing the product, not a bug.
+
+#### Internals
+
+- Forecast parsing now scans every `forecasts[]` entry plus the day level, covering towns-cities and rural page shapes with one rule.
+- `tomorrow_*` values are derived from the normalised 7-day data instead of a separate injection path.
+- New rural (Kumeu) API fixtures; test suite extended to cover every page-shape heuristic (towns/rural/day-level-only/missing-module cases).
+
+---
+
 ## v1.0.1
 
 > **Note:** v1.0.0 was tagged before Phase 3 code changes were committed; v1.0.1 ensures the release zip matches the documented changes.

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,9 +2,11 @@
 
 ---
 
-## v1.1.0
+## v2026.7.0
 
-### Rural locations fixed, correct rain probabilities
+### Rural locations fixed, correct rain probabilities — and a new version scheme
+
+> **Versioning change:** this integration now uses Home Assistant–style calendar versioning (`YYYY.M.patch`), so v1.0.1 is followed by v2026.7.0. Upgrades through HACS are unaffected.
 
 Fixes [#2](https://github.com/nagelm/metservice-weather/issues/2) and [#3](https://github.com/nagelm/metservice-weather/issues/3); delivers the rural-town half of [#4](https://github.com/nagelm/metservice-weather/issues/4).
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-# Test harness — keep this pair matched: pytest-homeassistant-custom-component
-# releases track specific Home Assistant versions.
-homeassistant==2026.5.1
-pytest-homeassistant-custom-component==0.13.330
+# Test harness — keep this pair matched: each pytest-homeassistant-custom-component
+# release pins one exact Home Assistant version (Dependabot keeps both fresh).
+homeassistant==2026.7.2
+pytest-homeassistant-custom-component==0.13.346

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+# Test harness — keep this pair matched: pytest-homeassistant-custom-component
+# releases track specific Home Assistant versions.
+homeassistant==2026.5.1
+pytest-homeassistant-custom-component==0.13.330

--- a/scripts/capture_fixtures.py
+++ b/scripts/capture_fixtures.py
@@ -10,6 +10,7 @@ Run from the project root:
 
 Requires: aiohttp, async_timeout (both present in the project venv).
 """
+
 import asyncio
 import json
 import re
@@ -59,14 +60,18 @@ async def expand_data_urls(session, data, parent=None, key=None, _depth=0):
                     result = await resp.json(content_type=None)
                 if parent is not None and key is not None:
                     parent[key] = result
-                await expand_data_urls(session, result, parent=parent, key=key, _depth=_depth + 1)
+                await expand_data_urls(
+                    session, result, parent=parent, key=key, _depth=_depth + 1
+                )
             except Exception as exc:
                 print(f"  [error] {full_url}: {exc}")
                 if parent is not None and key is not None:
                     parent[key] = None
         else:
             for k in list(data.keys()):
-                await expand_data_urls(session, data[k], parent=data, key=k, _depth=_depth)
+                await expand_data_urls(
+                    session, data[k], parent=data, key=k, _depth=_depth
+                )
     elif isinstance(data, list):
         for idx, item in enumerate(data):
             await expand_data_urls(session, item, parent=data, key=idx, _depth=_depth)
@@ -81,6 +86,7 @@ def inject_derived_fields(result_current, result_daily):
     # Drying index parsing
     try:
         drying_states = None
+
         # Walk result_current looking for dryingState (simplified get_from_dict)
         def find_key(data, target, _d=0):
             if _d > 15:
@@ -109,7 +115,9 @@ def inject_derived_fields(result_current, result_daily):
                 elif text.startswith("Afternoon:"):
                     drying_afternoon = text.removeprefix("Afternoon:").strip()
                 elif text.lower().startswith("next good day"):
-                    drying_next_good_day = text.split(":", 1)[-1].strip() if ":" in text else text
+                    drying_next_good_day = (
+                        text.split(":", 1)[-1].strip() if ":" in text else text
+                    )
                 elif text:
                     drying_morning = text
             if drying_afternoon is None and drying_morning is not None:
@@ -174,12 +182,25 @@ async def capture_location(session, fixtures_dir, name, location):
                     for item in module.get("content", []):
                         if item.get("iconName") == "pollen" and "html" in item:
                             html = item["html"]
-                            level_m = re.search(r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>', html)
-                            plants_m = re.search(r'</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)', html, re.IGNORECASE)
-                            result_current["pollen"] = {"pollenLevels": {
-                                "level": level_m.group(1).strip() if level_m else None,
-                                "type": plants_m.group(1).strip() if plants_m else None,
-                            }}
+                            level_m = re.search(
+                                r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>',
+                                html,
+                            )
+                            plants_m = re.search(
+                                r"</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)",
+                                html,
+                                re.IGNORECASE,
+                            )
+                            result_current["pollen"] = {
+                                "pollenLevels": {
+                                    "level": level_m.group(1).strip()
+                                    if level_m
+                                    else None,
+                                    "type": plants_m.group(1).strip()
+                                    if plants_m
+                                    else None,
+                                }
+                            }
     except Exception as exc:
         print(f"  [warn] pollen fetch failed: {exc}")
 
@@ -211,13 +232,16 @@ async def capture_location(session, fixtures_dir, name, location):
 
 
 async def main():
+    """Capture fixtures for the locations named on the command line (default: all)."""
     fixtures_dir = Path(__file__).parent.parent / "tests" / "fixtures"
     fixtures_dir.mkdir(parents=True, exist_ok=True)
 
     wanted = sys.argv[1:] or list(LOCATIONS)
     unknown = [n for n in wanted if n not in LOCATIONS]
     if unknown:
-        raise SystemExit(f"Unknown location name(s): {unknown}; known: {list(LOCATIONS)}")
+        raise SystemExit(
+            f"Unknown location name(s): {unknown}; known: {list(LOCATIONS)}"
+        )
 
     connector = aiohttp.TCPConnector(limit=10)
     async with aiohttp.ClientSession(connector=connector) as session:

--- a/scripts/capture_fixtures.py
+++ b/scripts/capture_fixtures.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 """Capture MetService API fixtures for coordinator contract tests.
 
-Fetches real data for Napier (public API) and saves post-expansion,
-post-injection coordinator data as JSON fixtures in tests/fixtures/.
+Fetches real data and saves post-expansion, post-injection coordinator
+data as JSON fixtures in tests/fixtures/.
 
 Run from the project root:
-    python scripts/capture_fixtures.py
+    python scripts/capture_fixtures.py            # capture every location
+    python scripts/capture_fixtures.py kumeu      # capture one location
 
 Requires: aiohttp, async_timeout (both present in the project venv).
 """
 import asyncio
 import json
 import re
+import sys
 from pathlib import Path
 
 import aiohttp
@@ -20,7 +22,14 @@ import async_timeout
 BASE_URL = "https://www.metservice.com"
 PUBLIC_URL = f"{BASE_URL}/publicData/webdata"
 WARNINGS_URL = f"{BASE_URL}/publicData/webdata/warnings-service"
-LOCATION = "/towns-cities/regions/hawkes-bay/locations/napier"
+
+# name → location path. "napier" exercises the towns-cities page shape,
+# "kumeu" the rural page shape (empty observations, regional + location
+# forecasts entries, day-level temps).
+LOCATIONS = {
+    "napier": "/towns-cities/regions/hawkes-bay/locations/napier",
+    "kumeu": "/rural/regions/auckland/locations/kumeu",
+}
 
 HEADERS = {
     "Accept-Encoding": "gzip",
@@ -64,27 +73,11 @@ async def expand_data_urls(session, data, parent=None, key=None, _depth=0):
 
 
 def inject_derived_fields(result_current, result_daily):
-    """Apply the same post-fetch injections the coordinator does."""
-    # Tomorrow's forecast from 7-day data
-    try:
-        all_days = (
-            result_daily.get("layout", {})
-            .get("primary", {})
-            .get("slots", {})
-            .get("main", {})
-            .get("modules", [{}])[0]
-            .get("days", [])
-        )
-        if len(all_days) > 1:
-            tmrw = all_days[1]
-            tf = (tmrw.get("forecasts") or [{}])[0]
-            result_current["tomorrow_condition"] = tmrw.get("condition")
-            result_current["tomorrow_temp_high"] = tf.get("highTemp")
-            result_current["tomorrow_temp_low"] = tf.get("lowTemp")
-            result_current["tomorrow_description"] = tf.get("statement")
-    except Exception as exc:
-        print(f"  [warn] tomorrow injection failed: {exc}")
+    """Apply the same post-fetch injections the coordinator does.
 
+    tomorrow_* fields are no longer injected — normalize_public_data
+    derives them from the 7-day data directly.
+    """
     # Drying index parsing
     try:
         drying_states = None
@@ -130,100 +123,107 @@ def inject_derived_fields(result_current, result_daily):
         print(f"  [warn] drying injection failed: {exc}")
 
 
+async def capture_location(session, fixtures_dir, name, location):
+    """Capture current + daily fixtures for one location."""
+    # 1. Current conditions
+    url = f"{PUBLIC_URL}{location}"
+    print(f"Fetching {url}")
+    async with async_timeout.timeout(15):
+        resp = await session.get(url, headers=HEADERS)
+        resp.raise_for_status()
+        result_current = await resp.json(content_type=None)
+
+    print("Expanding dataUrls in result_current ...")
+    await expand_data_urls(session, result_current)
+
+    # 2. Warnings
+    loc_type = result_current["location"]["type"]
+    loc_key = result_current["location"]["key"]
+    warn_url = f"{WARNINGS_URL}/{loc_type}/{loc_key}"
+    print(f"Fetching warnings {warn_url}")
+    async with async_timeout.timeout(15):
+        resp = await session.get(warn_url, headers=HEADERS)
+        result_warnings = await resp.json(content_type=None)
+    await expand_data_urls(session, result_warnings)
+
+    warnings_list = [
+        f"{w['name']}, {w['text']}, {w['threatPeriod']}"
+        for w in result_warnings.get("warnings", [])
+    ]
+    result_current["weather_warnings"] = (
+        "\n".join(warnings_list) if warnings_list else "No warnings"
+    )
+
+    # 3. Pollen (best-effort)
+    pollen_url = f"{PUBLIC_URL}{location}/airborne-allergens"
+    print(f"Fetching pollen {pollen_url}")
+    result_current["pollen"] = {"pollenLevels": {"level": None, "type": None}}
+    try:
+        async with async_timeout.timeout(10):
+            resp = await session.get(pollen_url, headers=HEADERS)
+            if resp.status == 200:
+                result_pollen = await resp.json(content_type=None)
+                modules = (
+                    result_pollen.get("layout", {})
+                    .get("primary", {})
+                    .get("slots", {})
+                    .get("main", {})
+                    .get("modules", [])
+                )
+                for module in modules:
+                    for item in module.get("content", []):
+                        if item.get("iconName") == "pollen" and "html" in item:
+                            html = item["html"]
+                            level_m = re.search(r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>', html)
+                            plants_m = re.search(r'</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)', html, re.IGNORECASE)
+                            result_current["pollen"] = {"pollenLevels": {
+                                "level": level_m.group(1).strip() if level_m else None,
+                                "type": plants_m.group(1).strip() if plants_m else None,
+                            }}
+    except Exception as exc:
+        print(f"  [warn] pollen fetch failed: {exc}")
+
+    # 4. Daily forecast
+    daily_url = f"{PUBLIC_URL}{location}/7-days"
+    print(f"Fetching {daily_url}")
+    async with async_timeout.timeout(15):
+        resp = await session.get(daily_url, headers=HEADERS)
+        resp.raise_for_status()
+        result_daily = await resp.json(content_type=None)
+    print("Expanding dataUrls in result_daily ...")
+    await expand_data_urls(session, result_daily)
+
+    # 5. Inject derived fields
+    print("Injecting derived fields ...")
+    inject_derived_fields(result_current, result_daily)
+
+    # Save
+    current_path = fixtures_dir / f"{name}_public_current.json"
+    daily_path = fixtures_dir / f"{name}_public_daily.json"
+
+    with open(current_path, "w", encoding="utf-8") as f:
+        json.dump(result_current, f, indent=2, default=str)
+    print(f"Saved {current_path} ({current_path.stat().st_size / 1024:.0f} KB)")
+
+    with open(daily_path, "w", encoding="utf-8") as f:
+        json.dump(result_daily, f, indent=2, default=str)
+    print(f"Saved {daily_path} ({daily_path.stat().st_size / 1024:.0f} KB)")
+
+
 async def main():
     fixtures_dir = Path(__file__).parent.parent / "tests" / "fixtures"
     fixtures_dir.mkdir(parents=True, exist_ok=True)
 
+    wanted = sys.argv[1:] or list(LOCATIONS)
+    unknown = [n for n in wanted if n not in LOCATIONS]
+    if unknown:
+        raise SystemExit(f"Unknown location name(s): {unknown}; known: {list(LOCATIONS)}")
+
     connector = aiohttp.TCPConnector(limit=10)
     async with aiohttp.ClientSession(connector=connector) as session:
-
-        # 1. Current conditions
-        url = f"{PUBLIC_URL}{LOCATION}"
-        print(f"Fetching {url}")
-        async with async_timeout.timeout(15):
-            resp = await session.get(url, headers=HEADERS)
-            resp.raise_for_status()
-            result_current = await resp.json(content_type=None)
-
-        print("Expanding dataUrls in result_current ...")
-        await expand_data_urls(session, result_current)
-
-        # 2. Warnings
-        loc_type = result_current["location"]["type"]
-        loc_key = result_current["location"]["key"]
-        warn_url = f"{WARNINGS_URL}/{loc_type}/{loc_key}"
-        print(f"Fetching warnings {warn_url}")
-        async with async_timeout.timeout(15):
-            resp = await session.get(warn_url, headers=HEADERS)
-            result_warnings = await resp.json(content_type=None)
-        await expand_data_urls(session, result_warnings)
-
-        warnings_list = [
-            f"{w['name']}, {w['text']}, {w['threatPeriod']}"
-            for w in result_warnings.get("warnings", [])
-        ]
-        result_current["weather_warnings"] = (
-            "\n".join(warnings_list) if warnings_list else "No warnings"
-        )
-
-        # 3. Pollen (best-effort)
-        pollen_url = f"{PUBLIC_URL}{LOCATION}/airborne-allergens"
-        print(f"Fetching pollen {pollen_url}")
-        try:
-            async with async_timeout.timeout(10):
-                resp = await session.get(pollen_url, headers=HEADERS)
-                if resp.status == 200:
-                    result_pollen = await resp.json(content_type=None)
-                    modules = (
-                        result_pollen.get("layout", {})
-                        .get("primary", {})
-                        .get("slots", {})
-                        .get("main", {})
-                        .get("modules", [])
-                    )
-                    pollen_data = {"pollenLevels": {"level": None, "type": None}}
-                    for module in modules:
-                        for item in module.get("content", []):
-                            if item.get("iconName") == "pollen" and "html" in item:
-                                html = item["html"]
-                                level_m = re.search(r'<span[^>]*class="status-[^"]*"[^>]*>([^<]+)</span>', html)
-                                plants_m = re.search(r'</span>(?:<br\s*/?>|</br>)(.*?)(?:<br\s*/?>|</br>|$)', html, re.IGNORECASE)
-                                pollen_data = {"pollenLevels": {
-                                    "level": level_m.group(1).strip() if level_m else None,
-                                    "type": plants_m.group(1).strip() if plants_m else None,
-                                }}
-                    result_current["pollen"] = pollen_data
-        except Exception as exc:
-            print(f"  [warn] pollen fetch failed: {exc}")
-            result_current["pollen"] = {"pollenLevels": {"level": None, "type": None}}
-
-        # 4. Daily forecast
-        daily_url = f"{PUBLIC_URL}{LOCATION}/7-days"
-        print(f"Fetching {daily_url}")
-        async with async_timeout.timeout(15):
-            resp = await session.get(daily_url, headers=HEADERS)
-            resp.raise_for_status()
-            result_daily = await resp.json(content_type=None)
-        print("Expanding dataUrls in result_daily ...")
-        await expand_data_urls(session, result_daily)
-
-        # 5. Inject derived fields
-        print("Injecting derived fields ...")
-        inject_derived_fields(result_current, result_daily)
-
-    # Save
-    current_path = fixtures_dir / "napier_public_current.json"
-    daily_path = fixtures_dir / "napier_public_daily.json"
-
-    with open(current_path, "w", encoding="utf-8") as f:
-        json.dump(result_current, f, indent=2, default=str)
-    size_kb = current_path.stat().st_size / 1024
-    print(f"\nSaved {current_path} ({size_kb:.0f} KB)")
-
-    with open(daily_path, "w", encoding="utf-8") as f:
-        json.dump(result_daily, f, indent=2, default=str)
-    size_kb = daily_path.stat().st_size / 1024
-    print(f"Saved {daily_path} ({size_kb:.0f} KB)")
+        for name in wanted:
+            print(f"\n=== Capturing {name} ({LOCATIONS[name]}) ===")
+            await capture_location(session, fixtures_dir, name, LOCATIONS[name])
 
     print("\nDone. Review fixture sizes before committing.")
 

--- a/scripts/get_cities.py
+++ b/scripts/get_cities.py
@@ -1,5 +1,5 @@
-# get_cities.py
-# this is a helper function to print out the list of cities for inclusion in const.py
+"""Dev helper: print the public API location list for inclusion in const.py."""
+
 import requests
 
 headers = {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,6 +3,7 @@
 # Usage: wsl bash scripts/lint.sh [--fix]
 set -e
 source /home/mattn/.venv/metservice-weather/bin/activate
-cd /mnt/c/Users/mattn/projects/metservice-weather
+# Run from the repo/worktree this script lives in, not a hardcoded path.
+cd "$(dirname "$(readlink -f "$0")")/.."
 ruff check --fix .
 ruff format .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,5 +4,6 @@
 # Example: wsl bash scripts/test.sh tests/test_coordinator_data.py -v
 set -e
 source /home/mattn/.venv/metservice-weather/bin/activate
-cd /mnt/c/Users/mattn/projects/metservice-weather
+# Run from the repo/worktree this script lives in, not a hardcoded path.
+cd "$(dirname "$(readlink -f "$0")")/.."
 exec pytest "${@:---q}"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the metservice_weather integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
 """Shared test fixtures for metservice_weather tests."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 MOCK_MARINE_RESPONSE = {
     "layout": {
         "search": {
-            "searchLocations": [{"items": [
-                {"heading": {"label": "Northland", "url": "/marine/regions/northland"}}
-            ]}]
+            "searchLocations": [
+                {
+                    "items": [
+                        {
+                            "heading": {
+                                "label": "Northland",
+                                "url": "/marine/regions/northland",
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/tests/fixtures/kumeu_public_current.json
+++ b/tests/fixtures/kumeu_public_current.json
@@ -1,0 +1,2099 @@
+{
+  "_usage": "This data is restricted and may only be used with explicit permission from MetService NZ. Contact dataenquiries@metservice.com",
+  "adConfig": {
+    "ac": "9734223",
+    "banner": {
+      "id": "sc-rur-atf-ban-ad1"
+    },
+    "interstitial": {
+      "id": "sc-rur-atf-inst-ad1",
+      "layout": {
+        "hideWhen": [
+          2,
+          3
+        ]
+      }
+    },
+    "targeting": {
+      "dynamicDataUrl": "/publicData/webdata/dynamicTargeting/null/93098/kumeu/null/auckland/rural/kumeu",
+      "staticData": [
+        {
+          "key": "apiKey",
+          "value": "kumeu"
+        },
+        {
+          "key": "type",
+          "value": "rural"
+        },
+        {
+          "key": "island",
+          "value": "rural-north-island"
+        },
+        {
+          "key": "region",
+          "value": "rural-auckland"
+        },
+        {
+          "key": "location",
+          "value": "rural-kumeu"
+        },
+        {
+          "key": "apiKey",
+          "value": "kumeu"
+        },
+        {
+          "key": "type",
+          "value": "rural"
+        },
+        {
+          "key": "island",
+          "value": "rural-north-island"
+        },
+        {
+          "key": "region",
+          "value": "rural-auckland"
+        },
+        {
+          "key": "location",
+          "value": "rural-kumeu"
+        },
+        {
+          "key": "page",
+          "value": "rural-48-hour"
+        },
+        {
+          "key": "section",
+          "value": "rural"
+        }
+      ]
+    }
+  },
+  "adDefinitions": {
+    "sc-rur-atf-ban-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-ban-ad1",
+        "id": "23312634890",
+        "name": "dsk-sc-rur-atf-ban-ad-1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ],
+          [
+            1280,
+            250
+          ],
+          [
+            1600,
+            250
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-ban-ad1",
+        "id": "23311296150",
+        "name": "mob-sc-rur-atf-ban-ad1",
+        "showAdvertiseWithMS": true,
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-atf-ban-ad1",
+        "id": "23312471111",
+        "name": "tab-land-sc-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-atf-ban-ad1",
+        "id": "23312470955",
+        "name": "tab-port-sc-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-ban-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-ban-ad2",
+        "id": "23311481265",
+        "name": "dsk-sc-rur-atf-ban-ad-2",
+        "showAdvertiseWithMS": true,
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-ban-ad2",
+        "id": "23312465066",
+        "name": "mob-sc-rur-atf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-atf-ban-ad2",
+        "id": "23312471153",
+        "name": "tab-port-sc-rur-atf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-inst-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-inst-ad1",
+        "id": "23311481490",
+        "name": "dsk-sc-rur-atf-inst-ad-1",
+        "sizes": [
+          [
+            970,
+            550
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-inst-ad1",
+        "id": "23311296153",
+        "name": "mob-sc-rur-atf-inst-ad1",
+        "sizes": [
+          [
+            320,
+            460
+          ],
+          [
+            320,
+            480
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-nav-ad-1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-nav-ad-1",
+        "id": "23314869626",
+        "name": "dsk-sc-rur-atf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            616,
+            240
+          ],
+          [
+            776,
+            240
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-til-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-til-ad1",
+        "id": "23312634686",
+        "name": "dsk-sc-rur-atf-til-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-til-ad1",
+        "id": "23311296156",
+        "name": "mob-sc-rur-atf-til-ad1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-til-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-til-ad2",
+        "id": "23343157556",
+        "name": "dsk-sc-rur-atf-til-ad-2",
+        "sizes": [
+          "fluid",
+          [
+            380,
+            80
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-til-ad2",
+        "id": "23342740033",
+        "name": "mob-sc-rur-atf-til-ad-2",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-ban-ad2": {
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-btf-ban-ad2",
+        "id": "23312470586",
+        "name": "tab-land-sc-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-ban-ad3": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-btf-ban-ad3",
+        "id": "23311481268",
+        "name": "dsk-sc-rur-btf-ban-ad-3",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-btf-ban-ad3",
+        "id": "23312470601",
+        "name": "tab-port-sc-rur-btf-ban-ad3",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-nav-ad1": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-btf-nav-ad1",
+        "id": "23319131483",
+        "name": "mob-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            296,
+            150
+          ],
+          [
+            296,
+            215
+          ],
+          [
+            345,
+            155
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-btf-nav-ad1",
+        "id": "23319131222",
+        "name": "tab-land-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            656,
+            240
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-btf-nav-ad1",
+        "id": "23319131225",
+        "name": "tab-port-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            345,
+            155
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-ban-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-ban-ad1",
+        "id": "23312622659",
+        "name": "dsk-sh-rur-atf-ban-ad-1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ],
+          [
+            1280,
+            250
+          ],
+          [
+            1600,
+            250
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-atf-ban-ad1",
+        "id": "23312465081",
+        "name": "mob-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sh-rur-atf-ban-ad1",
+        "id": "23312471132",
+        "name": "tab-land-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sh-rur-atf-ban-ad1",
+        "id": "23312470976",
+        "name": "tab-port-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-ban-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-ban-ad2",
+        "id": "23312634917",
+        "name": "dsk-sh-rur-atf-ban-ad-2",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-inst-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-inst-ad1",
+        "id": "23312634713",
+        "name": "dsk-sh-rur-atf-inst-ad-1",
+        "sizes": [
+          [
+            970,
+            550
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-atf-inst-ad1",
+        "id": "23311296213",
+        "name": "mob-sh-rur-atf-inst-ad1",
+        "sizes": [
+          [
+            320,
+            460
+          ],
+          [
+            320,
+            480
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-map-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-map-ad1",
+        "id": "23314878272",
+        "name": "dsk-sh-rur-atf-map-ad-1",
+        "sizes": [
+          [
+            300,
+            600
+          ],
+          [
+            1280,
+            775
+          ],
+          [
+            1600,
+            792
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-ban-ad2": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-btf-ban-ad2",
+        "id": "23311296216",
+        "name": "mob-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sh-rur-btf-ban-ad2",
+        "id": "23312470943",
+        "name": "tab-land-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sh-rur-btf-ban-ad2",
+        "id": "23312470610",
+        "name": "tab-port-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-ban-ad3": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-btf-ban-ad3",
+        "id": "23311481289",
+        "name": "dsk-sh-rur-btf-ban-ad-3",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-til-ad1": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-btf-til-ad1",
+        "id": "23311296219",
+        "name": "mob-sh-rur-btf-til-ad1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      }
+    }
+  },
+  "isSkiSeason": "false",
+  "layout": {
+    "last": {
+      "modules": [
+        {
+          "id": "sc-rur-btf-ban-ad2",
+          "layout": {
+            "hideWhen": [
+              1,
+              2,
+              4,
+              5
+            ]
+          },
+          "name": "advert/1"
+        }
+      ]
+    },
+    "name": "five-up/1",
+    "navigation": {
+      "links": [
+        {
+          "label": "Next 48 Hours",
+          "url": "/rural/regions/auckland/locations/kumeu"
+        },
+        {
+          "label": "7 Days",
+          "url": "/rural/regions/auckland/locations/kumeu/7-days"
+        },
+        {
+          "label": "Extended",
+          "url": "/rural/regions/auckland/locations/kumeu/extended"
+        },
+        {
+          "label": "Water Activities",
+          "url": "/rural/regions/auckland/locations/kumeu/water-activities"
+        },
+        {
+          "label": "Nearby Forecasts",
+          "url": "/rural/regions/auckland/locations/kumeu/nearby-forecasts"
+        },
+        {
+          "label": "Airborne Allergens",
+          "url": "/rural/regions/auckland/locations/kumeu/airborne-allergens"
+        },
+        {
+          "label": "Past Weather",
+          "url": "/rural/regions/auckland/locations/kumeu/past-weather"
+        }
+      ]
+    },
+    "primary": {
+      "slots": {
+        "first": {
+          "modules": []
+        },
+        "left-major": {
+          "modules": [
+            {},
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  3,
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        },
+        "left-minor": {
+          "modules": [
+            {
+              "name": "remove-module",
+              "showWhen": "never",
+              "type": "module"
+            },
+            {
+              "dryingIndex": {},
+              "items": [
+                {
+                  "dataModule": "airborne-allergens",
+                  "displayOrder": 1,
+                  "html": [
+                    "<a href='/rural/regions/auckland/locations/kumeu/airborne-allergens'>See more</a>"
+                  ],
+                  "icon": "pollen-risk",
+                  "sponsor": {
+                    "image": "/files/images/allergens/lp_logo.png",
+                    "maxHeight": 1.5,
+                    "text": "Here to help you feel your best ",
+                    "url": "https://www.lifepharmacy.co.nz/blogs/health-hq/about-allergies-1"
+                  },
+                  "subTitle": [
+                    {
+                      "state": "status-medium-good",
+                      "text": "Imminent: Pinus Radiata, Wattle"
+                    },
+                    {
+                      "state": "status-good",
+                      "text": "Low: Cedar, Fungal Spores"
+                    }
+                  ],
+                  "title": "Airborne Allergen Forecast"
+                }
+              ],
+              "mainSponsor": {
+                "sponsorImage": "",
+                "sponsorURL": "https://www.lifepharmacy.co.nz/blogs/health-hq/about-allergies-1"
+              },
+              "name": "integrations",
+              "title": "Allergens",
+              "uv": {
+                "displayEndOfSeasonMessage": "",
+                "displayOrder": 3
+              }
+            },
+            {
+              "id": "sc-rur-atf-til-ad1",
+              "layout": {
+                "hideWhen": [
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "name": "remove-module",
+              "showWhen": "never",
+              "type": "module"
+            }
+          ]
+        },
+        "main": {
+          "modules": [
+            {
+              "days": [
+                {
+                  "condition": "partly-cloudy",
+                  "date": "2026-07-15T12:00:00+12:00",
+                  "fireWeatherData": [],
+                  "forecasts": [
+                    {
+                      "statement": "Partly cloudy. Light winds.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 17,
+                      "lowTemp": 5,
+                      "rainFall1": 50.0,
+                      "rainFall10": 5.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 17,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T16:46:00+12:00",
+                  "lowTemp": 5,
+                  "statement": "Partly cloudy. Light winds.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "few-showers",
+                  "date": "2026-07-16T12:00:00+12:00",
+                  "fireWeatherData": [],
+                  "forecasts": [
+                    {
+                      "statement": "Areas of low cloud or fog, lifting and becoming partly cloudy in the morning, then the odd shower developing toward evening, possibly heavy. Northerlies, turning westerly in the afternoon.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 17,
+                      "lowTemp": 7,
+                      "rainFall1": 50.0,
+                      "rainFall10": 5.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 17,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T11:13:00+12:00",
+                  "lowTemp": 7,
+                  "statement": "Areas of low cloud or fog, lifting and becoming partly cloudy in the morning, then the odd shower developing toward evening, possibly heavy. Northerlies, turning westerly in the afternoon.",
+                  "title": "Auckland Regional Forecast"
+                }
+              ],
+              "disclaimer": "",
+              "information": [
+                {
+                  "icon": "temp-high",
+                  "key": "maxTemp",
+                  "link": "",
+                  "text": "High: Forecast for the calendar day. Usually occurs in the afternoon."
+                },
+                {
+                  "icon": "temp-low",
+                  "key": "minTemp",
+                  "link": "",
+                  "text": "Low: Forecast between noon on the calendar day and noon the following day.  Usually occurs around dawn."
+                },
+                {
+                  "icon": "",
+                  "key": "periods",
+                  "link": "https://about.metservice.com/our-company/learning-centre/weather-icons-explained",
+                  "text": "Forecast times: Overnight: Midnight - 6am, Morning: 6am - Noon, Afternoon: Noon - 6pm, Evening: 6pm - Midnight."
+                }
+              ],
+              "mobile": {
+                "expandDaysAll": true
+              },
+              "name": "city-forecast/tabs/1",
+              "type": "module"
+            },
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "id": "sc-rur-atf-nav-ad-1",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "graph": {
+                "columns": [
+                  {
+                    "date": "2026-07-15T19:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-15T20:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-15T21:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "10",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-15T22:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "10",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-15T23:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T00:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "8",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T01:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "8",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T02:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "7",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T03:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "7",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T04:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "7",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T05:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "7",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T06:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "6",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T07:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "6",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T08:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "6",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T09:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "8",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "6"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T10:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "NW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T11:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "14",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "11"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T12:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "16",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "15"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T13:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "16",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "17"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T14:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "16",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "17"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T15:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "16",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "17"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T16:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "16",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "17"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T17:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "14",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "13"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T18:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "13",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "11"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T19:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "12",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T20:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "12",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T21:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "12",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T22:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-16T23:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T00:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T01:00:00+12:00",
+                    "rainFallPerHour": "0.2",
+                    "rainfall": "0.2",
+                    "temperature": "10",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T02:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "10",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T03:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T04:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T05:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T06:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T07:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "9",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T08:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "10",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "7"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T09:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "11",
+                    "wind": {
+                      "direction": "W",
+                      "speed": "9"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T10:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "13",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "13"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T11:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "14",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "15"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T12:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "15",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "17"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T13:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "15",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "19"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T14:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "15",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "19"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T15:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "15",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "19"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T16:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "14",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "19"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T17:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "13",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "15"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T18:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "12",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "11"
+                    }
+                  },
+                  {
+                    "date": "2026-07-17T19:00:00+12:00",
+                    "rainFallPerHour": "0",
+                    "rainfall": 0.0,
+                    "temperature": "12",
+                    "wind": {
+                      "direction": "SW",
+                      "speed": "9"
+                    }
+                  }
+                ],
+                "series": [
+                  {
+                    "count": 0,
+                    "label": "Observed",
+                    "start": 0
+                  },
+                  {
+                    "count": 49,
+                    "label": "Forecast",
+                    "start": 0
+                  }
+                ],
+                "sunriseSunset": [
+                  {
+                    "date": "2026-07-15T00:00:00+12:00",
+                    "riseHour": 8,
+                    "setHour": 17,
+                    "sunRise": "7:31am",
+                    "sunRiseISO": "2026-07-15T07:31:00+12:00",
+                    "sunSet": "5:25pm",
+                    "sunSetISO": "2026-07-15T17:25:00+12:00"
+                  },
+                  {
+                    "date": "2026-07-16T00:00:00+12:00",
+                    "riseHour": 8,
+                    "setHour": 17,
+                    "sunRise": "7:30am",
+                    "sunRiseISO": "2026-07-16T07:30:00+12:00",
+                    "sunSet": "5:25pm",
+                    "sunSetISO": "2026-07-16T17:25:00+12:00"
+                  },
+                  {
+                    "date": "2026-07-17T00:00:00+12:00",
+                    "riseHour": 8,
+                    "setHour": 17,
+                    "sunRise": "7:30am",
+                    "sunRiseISO": "2026-07-17T07:30:00+12:00",
+                    "sunSet": "5:26pm",
+                    "sunSetISO": "2026-07-17T17:26:00+12:00"
+                  }
+                ]
+              },
+              "keys": [
+                {
+                  "items": [
+                    {
+                      "label": "Calm: 0"
+                    },
+                    {
+                      "icon": "wind-north-light",
+                      "label": "Light Winds: 1 - 14"
+                    },
+                    {
+                      "icon": "wind-north-moderate",
+                      "label": "Moderate: 15 - 29"
+                    },
+                    {
+                      "icon": "wind-north-fresh",
+                      "label": "Fresh: 30 - 39"
+                    },
+                    {
+                      "icon": "wind-north-strong",
+                      "label": "Strong: 40 - 62"
+                    },
+                    {
+                      "icon": "wind-north-gale",
+                      "label": "Gale: 63 - 89"
+                    },
+                    {
+                      "icon": "wind-north-gale",
+                      "label": "Severe Gale: > 89"
+                    }
+                  ],
+                  "label": "Wind (km/h)"
+                },
+                {
+                  "items": [
+                    {
+                      "className": "rainfall-light",
+                      "icon": "rainfall-light",
+                      "label": "Light: 0.2 - 2.0"
+                    },
+                    {
+                      "className": "rainfall-moderate",
+                      "icon": "rainfall-moderate",
+                      "label": "Moderate: 2.1 - 6.0"
+                    },
+                    {
+                      "className": "rainfall-heavy",
+                      "icon": "rainfall-heavy",
+                      "label": "Heavy: 6.1 - 25"
+                    },
+                    {
+                      "className": "rainfall-torrential",
+                      "icon": "rainfall-torrential",
+                      "label": "Torrential: > 25"
+                    }
+                  ],
+                  "label": "Rain (mm/h)"
+                }
+              ],
+              "labels": [
+                "",
+                "Rainfall (mm/h)",
+                "Temperature (\u00b0C)",
+                "Avg wind speed (not gusts) in km/h"
+              ],
+              "name": "forty-eight-hour-forecast/1",
+              "notes": [
+                {
+                  "text": "Total rainfall so far today: 0.0 mm. Total rainfall forecast for today: 0.0 mm"
+                }
+              ],
+              "notesLast": [
+                {
+                  "text": "The hourly model data shown can differ from the written forecast and icons, which are produced by MetService meteorologists and take into account model data along with many other data sources. If they differ significantly, please use the text forecasts."
+                },
+                {
+                  "text": "Forecast data is specifically generated for Whenuapai Automatic Weather Station (93098). Rainfall shown is for the sum up to the hour. Wind speed, wind direction and temperature are the observed or forecast values at the given hour."
+                }
+              ],
+              "title": "Hourly Observations and Forecast",
+              "type": "module",
+              "types": [
+                "date",
+                "rainfall",
+                "temperature",
+                "wind"
+              ]
+            },
+            {
+              "advert": {
+                "id": "sc-rur-atf-til-ad2"
+              },
+              "iconName": "tv",
+              "layout": {
+                "hideWhen": [
+                  4,
+                  5
+                ]
+              },
+              "link": {
+                "label": "See more video forecasts",
+                "url": "/video-forecasts"
+              },
+              "name": "video/youtube",
+              "playlist": {
+                "id": "PLmL1PKunD7-JNK2QdVgV3m1nezKAd5_Na",
+                "title": "Regional Forecast"
+              },
+              "title": "Regional Forecast",
+              "urlSlug": "video-forecast"
+            },
+            {
+              "id": "sc-rur-btf-nav-ad1",
+              "layout": {
+                "hideWhen": [
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        },
+        "right": {
+          "modules": [
+            {
+              "advert": {
+                "id": "sc-rur-atf-til-ad2"
+              },
+              "iconName": "tv",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "link": {
+                "label": "See more video forecasts",
+                "url": "/video-forecasts"
+              },
+              "name": "video/youtube",
+              "playlist": {
+                "id": "PLmL1PKunD7-JNK2QdVgV3m1nezKAd5_Na",
+                "title": "Regional Forecast"
+              },
+              "title": "Regional Forecast",
+              "urlSlug": "video-forecast"
+            },
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "id": "sc-rur-btf-ban-ad3",
+              "layout": {
+                "hideWhen": [
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-radar-auckland.jpg?v=1",
+              "name": "image-tile-compact/1",
+              "title": "Auckland Rain Radar",
+              "type": "module",
+              "url": "/maps-radar/rain/radar/auckland"
+            }
+          ]
+        }
+      }
+    },
+    "search": null,
+    "secondary": {
+      "slots": {
+        "major": {
+          "modules": [
+            {
+              "iconName": "map",
+              "items": [
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_rain-forecast-3day.jpg?v=1",
+                  "title": "3 day forecast",
+                  "url": "/maps-radar/forecast/3-days"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_tasman_surface-pressure.jpg?v=1",
+                  "title": "Tasman surface pressure",
+                  "url": "/maps-radar/surface-pressure/tasman-sea-new-zealand"
+                },
+                {
+                  "image": "/files/images/weather-stations-belt-north.png",
+                  "title": "Your weather",
+                  "url": "/maps-radar/weather-stations/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_rain-radar-auckland.jpg?v=1",
+                  "title": "Rain radar",
+                  "url": "/maps-radar/rain/radar/auckland"
+                }
+              ],
+              "itemsMobile": [
+                {
+                  "image": "/files/images/your-weather-static.png",
+                  "title": "Your weather",
+                  "url": "/maps-radar/weather-stations/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-radar-auckland.jpg?v=1",
+                  "title": "Rain radar",
+                  "url": "/maps-radar/rain/radar/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-forecast-3day.jpg?v=1",
+                  "title": "3 day forecast",
+                  "url": "/maps-radar/forecast/3-days"
+                }
+              ],
+              "link": {
+                "label": "View all maps & radar",
+                "url": "/maps-radar/rain/radar"
+              },
+              "name": "belt",
+              "title": "Kumeu Maps & Radar",
+              "type": "module",
+              "urlSlug": "maps-and-radar"
+            },
+            {
+              "locations": [
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/auckland",
+                  "name": "Auckland",
+                  "tidesData": [
+                    {
+                      "height": "0.6",
+                      "time": "01:13",
+                      "timeISO": "2026-07-15T01:13:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.3",
+                      "time": "07:36",
+                      "timeISO": "2026-07-15T07:36:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.4",
+                      "time": "13:37",
+                      "timeISO": "2026-07-15T13:37:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "20:05",
+                      "timeISO": "2026-07-15T20:05:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/onehunga",
+                  "name": "Onehunga",
+                  "tidesData": [
+                    {
+                      "height": "0.6",
+                      "time": "04:57",
+                      "timeISO": "2026-07-15T04:57:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "4.0",
+                      "time": "11:10",
+                      "timeISO": "2026-07-15T11:10:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.5",
+                      "time": "17:17",
+                      "timeISO": "2026-07-15T17:17:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "4.3",
+                      "time": "23:35",
+                      "timeISO": "2026-07-15T23:35:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/raglan/tides/locations/raglan",
+                  "name": "Raglan",
+                  "tidesData": [
+                    {
+                      "height": "0.3",
+                      "time": "04:20",
+                      "timeISO": "2026-07-15T04:20:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.2",
+                      "time": "10:42",
+                      "timeISO": "2026-07-15T10:42:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.2",
+                      "time": "16:38",
+                      "timeISO": "2026-07-15T16:38:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "23:08",
+                      "timeISO": "2026-07-15T23:08:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/piha/tides/locations/muriwai-beach",
+                  "name": "Muriwai Beach",
+                  "tidesData": [
+                    {
+                      "height": "",
+                      "time": "04:27",
+                      "timeISO": "2026-07-15T04:27:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "10:30",
+                      "timeISO": "2026-07-15T10:30:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "",
+                      "time": "16:47",
+                      "timeISO": "2026-07-15T16:47:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "22:55",
+                      "timeISO": "2026-07-15T22:55:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/piha/tides/locations/pouto-point",
+                  "name": "Pouto Point",
+                  "tidesData": [
+                    {
+                      "height": "0.4",
+                      "time": "04:47",
+                      "timeISO": "2026-07-15T04:47:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.3",
+                      "time": "10:57",
+                      "timeISO": "2026-07-15T10:57:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.4",
+                      "time": "17:06",
+                      "timeISO": "2026-07-15T17:06:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "23:23",
+                      "timeISO": "2026-07-15T23:23:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/maraetai",
+                  "name": "Maraetai",
+                  "tidesData": [
+                    {
+                      "height": "",
+                      "time": "00:58",
+                      "timeISO": "2026-07-15T00:58:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "07:21",
+                      "timeISO": "2026-07-15T07:21:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "",
+                      "time": "13:22",
+                      "timeISO": "2026-07-15T13:22:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "19:50",
+                      "timeISO": "2026-07-15T19:50:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                }
+              ],
+              "name": "tile-table/1",
+              "title": "Kumeu Tides Overview",
+              "type": "module",
+              "types": [
+                "tides"
+              ],
+              "urlSlug": "tides"
+            },
+            {
+              "iconName": "sun-moon",
+              "moonPhases": [
+                {
+                  "date": "21 Jul",
+                  "dateISO": "2026-07-21T22:55:48+12:00",
+                  "phase": "FIRST"
+                },
+                {
+                  "date": "30 Jul",
+                  "dateISO": "2026-07-30T02:47:31+12:00",
+                  "phase": "FULL"
+                },
+                {
+                  "date": "6 Aug",
+                  "dateISO": "2026-08-06T14:16:55+12:00",
+                  "phase": "LAST"
+                },
+                {
+                  "date": "13 Aug",
+                  "dateISO": "2026-08-13T05:45:15+12:00",
+                  "phase": "NEW"
+                }
+              ],
+              "name": "sun-and-moon",
+              "riseSet": {
+                "moonRise": "8:10am",
+                "moonSet": "6:12pm",
+                "sunRise": "7:31am",
+                "sunSet": "5:25pm"
+              },
+              "title": "Sun & Moon",
+              "type": "module",
+              "urlSlug": "sun-and-moon"
+            },
+            {
+              "iconName": "extremes",
+              "items": [
+                {
+                  "icon": "temp-high",
+                  "text": "Featherston",
+                  "title": "Highest",
+                  "value": "15.0\u00b0"
+                },
+                {
+                  "icon": "temp-low",
+                  "text": "Twizel",
+                  "title": "Lowest",
+                  "value": "0.1\u00b0"
+                },
+                {
+                  "icon": "windy",
+                  "text": "Featherston",
+                  "title": "Windiest",
+                  "value": "37km/h"
+                },
+                {
+                  "icon": "cloud-rain",
+                  "text": "Hokitika",
+                  "title": "Wettest",
+                  "value": "11.0mm"
+                }
+              ],
+              "name": "icon-list/1",
+              "title": "Current Extremes",
+              "type": "module",
+              "urlSlug": "current-extremes"
+            },
+            {
+              "content": "<div><a href='/news/weather-news'><b>Temperatures rise as westerly winds return</b></a></div><div class=\"u-mT-xs u-mB-xs fineprint u-textGrey\">Issued: <span>12:02pm Mon, 13 Jul</span></div><div>- After a chilly weekend, temperatures are heating up early this week. <br>- A band of rain brings possible thunderstorms and strong wind gusts to western areas, especially about the South Island.  <br>- Strong northwest winds are also expected early ...</div><span><img src=\"/IcePics/fc/1e8537-19f58213880-19f58213880-19f58213880-19f58c7d8c0.png width=\"200\" height=\"200\" \"></span><br>",
+              "name": "html-renderer",
+              "title": "Weather News",
+              "type": "module",
+              "urlSlug": "weather-news"
+            }
+          ]
+        },
+        "minor": {
+          "modules": []
+        },
+        "right": {
+          "modules": [
+            {
+              "id": "sc-rur-btf-ban-ad3",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        }
+      }
+    },
+    "type": "layout"
+  },
+  "location": {
+    "favouriteKey": "auckland/kumeu",
+    "favouriteType": "rural",
+    "key": "kumeu",
+    "label": "Kumeu",
+    "type": "rural",
+    "warningDataUrl": "/publicData/webdata/warnings-service/rural/kumeu",
+    "websiteLocation": "kumeu",
+    "websiteRegion": "auckland",
+    "websiteSection": "rural"
+  },
+  "metadata": {
+    "appleItunesApp": "app-id=525900888",
+    "author": "MetService",
+    "canonicalUrl": "https://www.metservice.com/rural/regions/auckland/locations/kumeu",
+    "description": "Kumeu weather from MetService: Accurate rural forecast for today, tomorrow, and this week. Stay informed with hourly observations, temperature, wind, rainfall, and more.",
+    "googlePlayApp": "app-id=com.metservice.phone.android",
+    "image": null,
+    "keywords": "Kumeu weather, weather, rural, rural weather, MetService, forecast, accurate forecast, extended forecast, today, tomorrow, this week, hourly observations, temperature, wind, rain, rainfall, maps, radar, New Zealand",
+    "siteName": "MetService",
+    "title": "Kumeu Rural Weather Forecast | MetService",
+    "twitterSite": "@metservicenz"
+  },
+  "searchLabel": "Kumeu - 48 Hours",
+  "type": "screen",
+  "url": "/rural/regions/auckland/locations/kumeu",
+  "weather_warnings": "No warnings",
+  "pollen": {
+    "pollenLevels": {
+      "level": "Low",
+      "type": "Cypress, Hazelnut, Cedar, Fungal Spores"
+    }
+  }
+}

--- a/tests/fixtures/kumeu_public_daily.json
+++ b/tests/fixtures/kumeu_public_daily.json
@@ -1,0 +1,1561 @@
+{
+  "_usage": "This data is restricted and may only be used with explicit permission from MetService NZ. Contact dataenquiries@metservice.com",
+  "adConfig": {
+    "ac": "9734223",
+    "banner": {
+      "id": "sc-rur-atf-ban-ad1"
+    },
+    "interstitial": {
+      "id": "sc-rur-atf-inst-ad1",
+      "layout": {
+        "hideWhen": [
+          2,
+          3
+        ]
+      }
+    },
+    "targeting": {
+      "dynamicDataUrl": "/publicData/webdata/dynamicTargeting/null/93098/kumeu/null/auckland/rural/kumeu",
+      "staticData": [
+        {
+          "key": "apiKey",
+          "value": "kumeu"
+        },
+        {
+          "key": "type",
+          "value": "rural"
+        },
+        {
+          "key": "island",
+          "value": "rural-north-island"
+        },
+        {
+          "key": "region",
+          "value": "rural-auckland"
+        },
+        {
+          "key": "location",
+          "value": "rural-kumeu"
+        },
+        {
+          "key": "apiKey",
+          "value": "kumeu"
+        },
+        {
+          "key": "type",
+          "value": "rural"
+        },
+        {
+          "key": "island",
+          "value": "rural-north-island"
+        },
+        {
+          "key": "region",
+          "value": "rural-auckland"
+        },
+        {
+          "key": "location",
+          "value": "rural-kumeu"
+        },
+        {
+          "key": "page",
+          "value": "rural-7-days"
+        },
+        {
+          "key": "section",
+          "value": "rural"
+        }
+      ]
+    }
+  },
+  "adDefinitions": {
+    "sc-rur-atf-ban-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-ban-ad1",
+        "id": "23312634890",
+        "name": "dsk-sc-rur-atf-ban-ad-1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ],
+          [
+            1280,
+            250
+          ],
+          [
+            1600,
+            250
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-ban-ad1",
+        "id": "23311296150",
+        "name": "mob-sc-rur-atf-ban-ad1",
+        "showAdvertiseWithMS": true,
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-atf-ban-ad1",
+        "id": "23312471111",
+        "name": "tab-land-sc-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-atf-ban-ad1",
+        "id": "23312470955",
+        "name": "tab-port-sc-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-ban-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-ban-ad2",
+        "id": "23311481265",
+        "name": "dsk-sc-rur-atf-ban-ad-2",
+        "showAdvertiseWithMS": true,
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-ban-ad2",
+        "id": "23312465066",
+        "name": "mob-sc-rur-atf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-atf-ban-ad2",
+        "id": "23312471153",
+        "name": "tab-port-sc-rur-atf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-inst-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-inst-ad1",
+        "id": "23311481490",
+        "name": "dsk-sc-rur-atf-inst-ad-1",
+        "sizes": [
+          [
+            970,
+            550
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-inst-ad1",
+        "id": "23311296153",
+        "name": "mob-sc-rur-atf-inst-ad1",
+        "sizes": [
+          [
+            320,
+            460
+          ],
+          [
+            320,
+            480
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-nav-ad-1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-nav-ad-1",
+        "id": "23314869626",
+        "name": "dsk-sc-rur-atf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            616,
+            240
+          ],
+          [
+            776,
+            240
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-til-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-til-ad1",
+        "id": "23312634686",
+        "name": "dsk-sc-rur-atf-til-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-til-ad1",
+        "id": "23311296156",
+        "name": "mob-sc-rur-atf-til-ad1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      }
+    },
+    "sc-rur-atf-til-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-atf-til-ad2",
+        "id": "23343157556",
+        "name": "dsk-sc-rur-atf-til-ad-2",
+        "sizes": [
+          "fluid",
+          [
+            380,
+            80
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-atf-til-ad2",
+        "id": "23342740033",
+        "name": "mob-sc-rur-atf-til-ad-2",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-ban-ad2": {
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-btf-ban-ad2",
+        "id": "23312470586",
+        "name": "tab-land-sc-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-ban-ad3": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sc-rur-btf-ban-ad3",
+        "id": "23311481268",
+        "name": "dsk-sc-rur-btf-ban-ad-3",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-btf-ban-ad3",
+        "id": "23312470601",
+        "name": "tab-port-sc-rur-btf-ban-ad3",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sc-rur-btf-nav-ad1": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sc-rur-btf-nav-ad1",
+        "id": "23319131483",
+        "name": "mob-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            296,
+            150
+          ],
+          [
+            296,
+            215
+          ],
+          [
+            345,
+            155
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sc-rur-btf-nav-ad1",
+        "id": "23319131222",
+        "name": "tab-land-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            656,
+            240
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sc-rur-btf-nav-ad1",
+        "id": "23319131225",
+        "name": "tab-port-sc-rur-btf-nav-ad-1",
+        "sizes": [
+          "fluid",
+          [
+            345,
+            155
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-ban-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-ban-ad1",
+        "id": "23312622659",
+        "name": "dsk-sh-rur-atf-ban-ad-1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ],
+          [
+            1280,
+            250
+          ],
+          [
+            1600,
+            250
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-atf-ban-ad1",
+        "id": "23312465081",
+        "name": "mob-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sh-rur-atf-ban-ad1",
+        "id": "23312471132",
+        "name": "tab-land-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ],
+          [
+            970,
+            90
+          ],
+          [
+            970,
+            250
+          ],
+          [
+            1024,
+            250
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sh-rur-atf-ban-ad1",
+        "id": "23312470976",
+        "name": "tab-port-sh-rur-atf-ban-ad1",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-ban-ad2": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-ban-ad2",
+        "id": "23312634917",
+        "name": "dsk-sh-rur-atf-ban-ad-2",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-inst-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-inst-ad1",
+        "id": "23312634713",
+        "name": "dsk-sh-rur-atf-inst-ad-1",
+        "sizes": [
+          [
+            970,
+            550
+          ]
+        ]
+      },
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-atf-inst-ad1",
+        "id": "23311296213",
+        "name": "mob-sh-rur-atf-inst-ad1",
+        "sizes": [
+          [
+            320,
+            460
+          ],
+          [
+            320,
+            480
+          ]
+        ]
+      }
+    },
+    "sh-rur-atf-map-ad1": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-atf-map-ad1",
+        "id": "23314878272",
+        "name": "dsk-sh-rur-atf-map-ad-1",
+        "sizes": [
+          [
+            300,
+            600
+          ],
+          [
+            1280,
+            775
+          ],
+          [
+            1600,
+            792
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-ban-ad2": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-btf-ban-ad2",
+        "id": "23311296216",
+        "name": "mob-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ],
+          [
+            336,
+            280
+          ]
+        ]
+      },
+      "tab-land": {
+        "def": "/ms/p/w/tab/tab-land-sh-rur-btf-ban-ad2",
+        "id": "23312470943",
+        "name": "tab-land-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ]
+        ]
+      },
+      "tab-port": {
+        "def": "/ms/p/w/tab/tab-port-sh-rur-btf-ban-ad2",
+        "id": "23312470610",
+        "name": "tab-port-sh-rur-btf-ban-ad2",
+        "sizes": [
+          [
+            300,
+            250
+          ],
+          [
+            728,
+            90
+          ],
+          [
+            760,
+            120
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-ban-ad3": {
+      "dsk": {
+        "def": "/ms/p/w/dsk/dsk-sh-rur-btf-ban-ad3",
+        "id": "23311481289",
+        "name": "dsk-sh-rur-btf-ban-ad-3",
+        "sizes": [
+          [
+            160,
+            600
+          ],
+          [
+            300,
+            250
+          ],
+          [
+            300,
+            600
+          ]
+        ]
+      }
+    },
+    "sh-rur-btf-til-ad1": {
+      "mob": {
+        "def": "/ms/p/w/mob/mob-sh-rur-btf-til-ad1",
+        "id": "23311296219",
+        "name": "mob-sh-rur-btf-til-ad1",
+        "sizes": [
+          "fluid",
+          [
+            320,
+            80
+          ],
+          [
+            320,
+            100
+          ],
+          [
+            320,
+            125
+          ],
+          [
+            300,
+            50
+          ],
+          [
+            300,
+            100
+          ],
+          [
+            300,
+            150
+          ],
+          [
+            380,
+            100
+          ]
+        ]
+      }
+    }
+  },
+  "isSkiSeason": "false",
+  "layout": {
+    "last": {
+      "modules": [
+        {
+          "id": "sc-rur-btf-ban-ad2",
+          "layout": {
+            "hideWhen": [
+              1,
+              2,
+              4,
+              5
+            ]
+          },
+          "name": "advert/1"
+        }
+      ]
+    },
+    "name": "five-up/1",
+    "navigation": {
+      "links": [
+        {
+          "label": "Next 48 Hours",
+          "url": "/rural/regions/auckland/locations/kumeu"
+        },
+        {
+          "label": "7 Days",
+          "url": "/rural/regions/auckland/locations/kumeu/7-days"
+        },
+        {
+          "label": "Extended",
+          "url": "/rural/regions/auckland/locations/kumeu/extended"
+        },
+        {
+          "label": "Water Activities",
+          "url": "/rural/regions/auckland/locations/kumeu/water-activities"
+        },
+        {
+          "label": "Nearby Forecasts",
+          "url": "/rural/regions/auckland/locations/kumeu/nearby-forecasts"
+        },
+        {
+          "label": "Airborne Allergens",
+          "url": "/rural/regions/auckland/locations/kumeu/airborne-allergens"
+        },
+        {
+          "label": "Past Weather",
+          "url": "/rural/regions/auckland/locations/kumeu/past-weather"
+        }
+      ]
+    },
+    "primary": {
+      "slots": {
+        "first": {
+          "modules": []
+        },
+        "left-major": {
+          "modules": [
+            {},
+            {
+              "id": "sc-rur-atf-til-ad1",
+              "layout": {
+                "hideWhen": [
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "dryingIndex": {},
+              "items": [
+                {
+                  "dataModule": "airborne-allergens",
+                  "displayOrder": 1,
+                  "html": [
+                    "<a href='/rural/regions/auckland/locations/kumeu/airborne-allergens'>See more</a>"
+                  ],
+                  "icon": "pollen-risk",
+                  "sponsor": {
+                    "image": "/files/images/allergens/lp_logo.png",
+                    "maxHeight": 1.5,
+                    "text": "Here to help you feel your best ",
+                    "url": "https://www.lifepharmacy.co.nz/blogs/health-hq/about-allergies-1"
+                  },
+                  "subTitle": [
+                    {
+                      "state": "status-medium-good",
+                      "text": "Imminent: Pinus Radiata, Wattle"
+                    },
+                    {
+                      "state": "status-good",
+                      "text": "Low: Cedar, Fungal Spores"
+                    }
+                  ],
+                  "title": "Airborne Allergen Forecast"
+                }
+              ],
+              "mainSponsor": {
+                "sponsorImage": "",
+                "sponsorURL": "https://www.lifepharmacy.co.nz/blogs/health-hq/about-allergies-1"
+              },
+              "name": "integrations",
+              "title": "Allergens",
+              "uv": {
+                "displayEndOfSeasonMessage": "",
+                "displayOrder": 3
+              }
+            },
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  3,
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        },
+        "left-minor": {
+          "modules": [
+            {
+              "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-forecast-3day.jpg?v=1",
+              "name": "image-tile-compact/1",
+              "title": "3 Day Forecast",
+              "type": "module",
+              "url": "/maps-radar/forecast/3-days"
+            },
+            {
+              "id": "sc-rur-btf-ban-ad3",
+              "layout": {
+                "hideWhen": [
+                  3,
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        },
+        "main": {
+          "modules": [
+            {
+              "days": [
+                {
+                  "condition": "partly-cloudy",
+                  "date": "2026-07-15T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Partly cloudy. Light winds.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 17,
+                      "lowTemp": 5,
+                      "rainFall1": 50.0,
+                      "rainFall10": 5.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 17,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T16:46:00+12:00",
+                  "lowTemp": 5,
+                  "statement": "Partly cloudy. Light winds.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "few-showers",
+                  "date": "2026-07-16T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Areas of low cloud or fog, lifting and becoming partly cloudy in the morning, then the odd shower developing toward evening, possibly heavy. Northerlies, turning westerly in the afternoon.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 17,
+                      "lowTemp": 7,
+                      "rainFall1": 50.0,
+                      "rainFall10": 5.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 17,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T11:13:00+12:00",
+                  "lowTemp": 7,
+                  "statement": "Areas of low cloud or fog, lifting and becoming partly cloudy in the morning, then the odd shower developing toward evening, possibly heavy. Northerlies, turning westerly in the afternoon.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "partly-cloudy",
+                  "date": "2026-07-17T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Mostly cloudy with isolated showers, clearing to fine in the morning. Southwesterlies.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 16,
+                      "lowTemp": 9,
+                      "rainFall1": 5.0,
+                      "rainFall10": 0.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 16,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T09:47:00+12:00",
+                  "lowTemp": 9,
+                  "statement": "Mostly cloudy with isolated showers, clearing to fine in the morning. Southwesterlies.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "cloudy",
+                  "date": "2026-07-18T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Cloud clearing and becoming fine in the evening. Southwesterlies.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 16,
+                      "lowTemp": 7,
+                      "rainFall1": 5.0,
+                      "rainFall10": 0.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 16,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T09:37:00+12:00",
+                  "lowTemp": 7,
+                  "statement": "Cloud clearing and becoming fine in the evening. Southwesterlies.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "partly-cloudy",
+                  "date": "2026-07-19T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Fine. Southwesterlies, dying out in the evening.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 16,
+                      "lowTemp": 5,
+                      "rainFall1": 10.0,
+                      "rainFall10": 5.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 16,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T09:37:00+12:00",
+                  "lowTemp": 5,
+                  "statement": "Fine. Southwesterlies, dying out in the evening.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "partly-cloudy",
+                  "date": "2026-07-20T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Partly cloudy, with isolated showers. Southeasterlies developing.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 15,
+                      "lowTemp": 5,
+                      "rainFall1": 50.0,
+                      "rainFall10": 10.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 15,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T06:34:00+12:00",
+                  "lowTemp": 5,
+                  "statement": "Partly cloudy, with isolated showers. Southeasterlies developing.",
+                  "title": "Auckland Regional Forecast"
+                },
+                {
+                  "condition": "fine",
+                  "date": "2026-07-21T12:00:00+12:00",
+                  "forecasts": [
+                    {
+                      "statement": "Fine with light winds.",
+                      "title": "Auckland Regional Forecast"
+                    },
+                    {
+                      "highTemp": 15,
+                      "lowTemp": 6,
+                      "rainFall1": 40.0,
+                      "rainFall10": 20.0,
+                      "statement": null,
+                      "title": "Kumeu Forecast"
+                    }
+                  ],
+                  "highTemp": 15,
+                  "isRural": "true",
+                  "issuedAt": "2026-07-15T12:35:00+12:00",
+                  "lowTemp": 6,
+                  "statement": "Fine with light winds.",
+                  "title": "Auckland Regional Forecast"
+                }
+              ],
+              "disclaimer": "Forecasts and temperatures for days 1-5 are produced by MetService meteorologists. Forecasts and temperatures for days 6-10 are automatically generated by MetService's computer weather modelling system.",
+              "information": [
+                {
+                  "icon": "temp-high",
+                  "key": "maxTemp",
+                  "link": "",
+                  "text": "High: Forecast for the calendar day. Usually occurs in the afternoon."
+                },
+                {
+                  "icon": "temp-low",
+                  "key": "minTemp",
+                  "link": "",
+                  "text": "Low: Forecast between noon on the calendar day and noon the following day.  Usually occurs around dawn."
+                },
+                {
+                  "icon": "",
+                  "key": "periods",
+                  "link": "https://about.metservice.com/our-company/learning-centre/weather-icons-explained",
+                  "text": "Forecast times: Overnight: Midnight - 6am, Morning: 6am - Noon, Afternoon: Noon - 6pm, Evening: 6pm - Midnight."
+                }
+              ],
+              "mobile": {
+                "expandDaysAll": false
+              },
+              "name": "city-forecast/tabs/1",
+              "type": "module"
+            },
+            {
+              "advert": {
+                "id": "sc-rur-atf-til-ad2"
+              },
+              "iconName": "tv",
+              "layout": {
+                "hideWhen": [
+                  4,
+                  5
+                ]
+              },
+              "link": {
+                "label": "See more video forecasts",
+                "url": "/video-forecasts"
+              },
+              "name": "video/youtube",
+              "playlist": {
+                "id": "PLmL1PKunD7-JNK2QdVgV3m1nezKAd5_Na",
+                "title": "Regional Forecast"
+              },
+              "title": "Regional Forecast",
+              "urlSlug": "video-forecast"
+            },
+            {
+              "id": "sc-rur-btf-ban-ad3",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            },
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  4,
+                  5
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        },
+        "right": {
+          "modules": [
+            {
+              "advert": {
+                "id": "sc-rur-atf-til-ad2"
+              },
+              "iconName": "tv",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "link": {
+                "label": "See more video forecasts",
+                "url": "/video-forecasts"
+              },
+              "name": "video/youtube",
+              "playlist": {
+                "id": "PLmL1PKunD7-JNK2QdVgV3m1nezKAd5_Na",
+                "title": "Regional Forecast"
+              },
+              "title": "Regional Forecast",
+              "urlSlug": "video-forecast"
+            },
+            {
+              "id": "sc-rur-atf-ban-ad2",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        }
+      }
+    },
+    "search": null,
+    "secondary": {
+      "slots": {
+        "major": {
+          "modules": [
+            {
+              "items": [
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_rain-forecast-3day.jpg?v=1",
+                  "title": "3 day forecast",
+                  "url": "/maps-radar/forecast/3-days"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_tasman_surface-pressure.jpg?v=1",
+                  "title": "Tasman surface pressure",
+                  "url": "/maps-radar/surface-pressure/tasman-sea-new-zealand"
+                },
+                {
+                  "image": "/files/images/weather-stations-belt-north.png",
+                  "title": "Your weather",
+                  "url": "/maps-radar/weather-stations/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/370x210_thumb_rain-radar-auckland.jpg?v=1",
+                  "title": "Rain radar",
+                  "url": "/maps-radar/rain/radar/auckland"
+                }
+              ],
+              "itemsMobile": [
+                {
+                  "image": "/files/images/your-weather-static.png",
+                  "title": "Your weather",
+                  "url": "/maps-radar/weather-stations/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-radar-auckland.jpg?v=1",
+                  "title": "Rain radar",
+                  "url": "/maps-radar/rain/radar/auckland"
+                },
+                {
+                  "image": "/dynamic/feeds/thumbnails/140x140_thumb_rain-forecast-3day.jpg?v=1",
+                  "title": "3 day forecast",
+                  "url": "/maps-radar/forecast/3-days"
+                }
+              ],
+              "name": "belt",
+              "title": "Auckland Maps & Radar",
+              "urlSlug": "maps-and-radar"
+            },
+            {
+              "locations": [
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/auckland",
+                  "name": "Auckland",
+                  "tidesData": [
+                    {
+                      "height": "0.6",
+                      "time": "01:13",
+                      "timeISO": "2026-07-15T01:13:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.3",
+                      "time": "07:36",
+                      "timeISO": "2026-07-15T07:36:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.4",
+                      "time": "13:37",
+                      "timeISO": "2026-07-15T13:37:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "20:05",
+                      "timeISO": "2026-07-15T20:05:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/onehunga",
+                  "name": "Onehunga",
+                  "tidesData": [
+                    {
+                      "height": "0.6",
+                      "time": "04:57",
+                      "timeISO": "2026-07-15T04:57:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "4.0",
+                      "time": "11:10",
+                      "timeISO": "2026-07-15T11:10:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.5",
+                      "time": "17:17",
+                      "timeISO": "2026-07-15T17:17:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "4.3",
+                      "time": "23:35",
+                      "timeISO": "2026-07-15T23:35:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/raglan/tides/locations/raglan",
+                  "name": "Raglan",
+                  "tidesData": [
+                    {
+                      "height": "0.3",
+                      "time": "04:20",
+                      "timeISO": "2026-07-15T04:20:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.2",
+                      "time": "10:42",
+                      "timeISO": "2026-07-15T10:42:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.2",
+                      "time": "16:38",
+                      "timeISO": "2026-07-15T16:38:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "23:08",
+                      "timeISO": "2026-07-15T23:08:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/piha/tides/locations/muriwai-beach",
+                  "name": "Muriwai Beach",
+                  "tidesData": [
+                    {
+                      "height": "",
+                      "time": "04:27",
+                      "timeISO": "2026-07-15T04:27:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "10:30",
+                      "timeISO": "2026-07-15T10:30:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "",
+                      "time": "16:47",
+                      "timeISO": "2026-07-15T16:47:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "22:55",
+                      "timeISO": "2026-07-15T22:55:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/piha/tides/locations/pouto-point",
+                  "name": "Pouto Point",
+                  "tidesData": [
+                    {
+                      "height": "0.4",
+                      "time": "04:47",
+                      "timeISO": "2026-07-15T04:47:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.3",
+                      "time": "10:57",
+                      "timeISO": "2026-07-15T10:57:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "0.4",
+                      "time": "17:06",
+                      "timeISO": "2026-07-15T17:06:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "3.5",
+                      "time": "23:23",
+                      "timeISO": "2026-07-15T23:23:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                },
+                {
+                  "link": "/marine/regions/east-auckland/tides/locations/maraetai",
+                  "name": "Maraetai",
+                  "tidesData": [
+                    {
+                      "height": "",
+                      "time": "00:58",
+                      "timeISO": "2026-07-15T00:58:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "07:21",
+                      "timeISO": "2026-07-15T07:21:00+12:00",
+                      "type": "HIGH"
+                    },
+                    {
+                      "height": "",
+                      "time": "13:22",
+                      "timeISO": "2026-07-15T13:22:00+12:00",
+                      "type": "LOW"
+                    },
+                    {
+                      "height": "",
+                      "time": "19:50",
+                      "timeISO": "2026-07-15T19:50:00+12:00",
+                      "type": "HIGH"
+                    }
+                  ]
+                }
+              ],
+              "name": "tile-table/1",
+              "title": "Kumeu Tides Overview",
+              "type": "module",
+              "types": [
+                "tides"
+              ],
+              "urlSlug": "tides"
+            },
+            {
+              "iconName": "sun-moon",
+              "moonPhases": [
+                {
+                  "date": "21 Jul",
+                  "dateISO": "2026-07-21T22:55:48+12:00",
+                  "phase": "FIRST"
+                },
+                {
+                  "date": "30 Jul",
+                  "dateISO": "2026-07-30T02:47:31+12:00",
+                  "phase": "FULL"
+                },
+                {
+                  "date": "6 Aug",
+                  "dateISO": "2026-08-06T14:16:55+12:00",
+                  "phase": "LAST"
+                },
+                {
+                  "date": "13 Aug",
+                  "dateISO": "2026-08-13T05:45:15+12:00",
+                  "phase": "NEW"
+                }
+              ],
+              "name": "sun-and-moon",
+              "riseSet": {
+                "moonRise": "8:10am",
+                "moonSet": "6:12pm",
+                "sunRise": "7:31am",
+                "sunSet": "5:25pm"
+              },
+              "title": "Sun & Moon",
+              "type": "module",
+              "urlSlug": "sun-and-moon"
+            },
+            {
+              "iconName": "extremes",
+              "items": [
+                {
+                  "icon": "temp-high",
+                  "text": "Featherston",
+                  "title": "Highest",
+                  "value": "15.0\u00b0"
+                },
+                {
+                  "icon": "temp-low",
+                  "text": "Twizel",
+                  "title": "Lowest",
+                  "value": "0.1\u00b0"
+                },
+                {
+                  "icon": "windy",
+                  "text": "Featherston",
+                  "title": "Windiest",
+                  "value": "37km/h"
+                },
+                {
+                  "icon": "cloud-rain",
+                  "text": "Hokitika",
+                  "title": "Wettest",
+                  "value": "11.0mm"
+                }
+              ],
+              "name": "icon-list/1",
+              "title": "Current Extremes",
+              "type": "module",
+              "urlSlug": "current-extremes"
+            },
+            {
+              "content": "<div><a href='/news/weather-news'><b>Temperatures rise as westerly winds return</b></a></div><div class=\"u-mT-xs u-mB-xs fineprint u-textGrey\">Issued: <span>12:02pm Mon, 13 Jul</span></div><div>- After a chilly weekend, temperatures are heating up early this week. <br>- A band of rain brings possible thunderstorms and strong wind gusts to western areas, especially about the South Island.  <br>- Strong northwest winds are also expected early ...</div><span><img src=\"/IcePics/fc/1e8537-19f58213880-19f58213880-19f58213880-19f58c7d8c0.png width=\"200\" height=\"200\" \"></span><br>",
+              "name": "html-renderer",
+              "title": "Weather News",
+              "type": "module",
+              "urlSlug": "weather-news"
+            }
+          ]
+        },
+        "minor": {
+          "modules": []
+        },
+        "right": {
+          "modules": [
+            {
+              "id": "sc-rur-btf-ban-ad3",
+              "layout": {
+                "hideWhen": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "name": "advert/1"
+            }
+          ]
+        }
+      }
+    },
+    "type": "layout"
+  },
+  "location": {
+    "favouriteKey": "auckland/kumeu",
+    "favouriteType": "rural",
+    "key": "kumeu",
+    "label": "Kumeu",
+    "type": "rural",
+    "warningDataUrl": "/publicData/webdata/warnings-service/rural/kumeu",
+    "websiteLocation": "kumeu",
+    "websiteRegion": "auckland",
+    "websiteSection": "rural"
+  },
+  "metadata": {
+    "appleItunesApp": "app-id=525900888",
+    "author": "MetService",
+    "canonicalUrl": "https://www.metservice.com/rural/regions/auckland/locations/kumeu/7-days",
+    "description": "Kumeu  7 day weather forecast, rain maps, rain radar and current conditions. MetService is New Zealand\u2019s national weather authority, providing accurate town, city and rural forecasts across the country.",
+    "googlePlayApp": "app-id=com.metservice.phone.android",
+    "image": null,
+    "keywords": "New Zealand,Zealand,New Zealand weather,NZ,NZ Weather,weather forecast,weather conditions,weather information,Urban,Rural,Town,City, Suburban,Humidity,Pressure,temperature,current temperature,rain,rainfall,raining,wind,windy,gale,gusts,historic weather,past weather,maps,weather maps,radar,rain radar,tides, sun, pollen, UV",
+    "siteName": "MetService",
+    "title": "Kumeu 7 Day Weather Forecast and Observations - MetService New Zealand",
+    "twitterSite": "@metservicenz"
+  },
+  "searchLabel": "Kumeu - 7 Days",
+  "type": "screen",
+  "url": "/rural/regions/auckland/locations/kumeu/7-days"
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -220,6 +220,12 @@ async def test_reconfigure(hass, mock_marine_session):
     assert result["reason"] == "reconfigure_successful"
     assert existing_entry.data[CONF_NAME] == "Napier Updated"
 
+    # The successful reconfigure reloads the entry, starting a coordinator
+    # refresh timer — unload so no timer lingers past the test.
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(existing_entry.entry_id)
+    await hass.async_block_till_done()
+
 
 # ---------------------------------------------------------------------------
 # Test 15 — location fetch exception is swallowed, step still shows

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 
-from custom_components.metservice_weather.const import DOMAIN, DEFAULT_LOCATION
+from custom_components.metservice_weather.const import DOMAIN
 from custom_components.metservice_weather.config_flow import (
     CONF_MARINE_REGION,
     WeatherFlowHandler,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the metservice_weather config flow."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant import config_entries
@@ -15,6 +16,7 @@ from homeassistant.const import CONF_NAME, CONF_LOCATION
 # ---------------------------------------------------------------------------
 # Test 1 — public API, no marine region
 # ---------------------------------------------------------------------------
+
 
 async def test_public_no_marine(hass, mock_marine_session):
     """User flow with public API and marine skipped creates entry."""
@@ -40,34 +42,48 @@ async def test_public_no_marine(hass, mock_marine_session):
 # Test 2 — public API with marine region (proceeds to locations step)
 # ---------------------------------------------------------------------------
 
+
 async def test_public_with_marine_region(hass, mock_coordinator_refresh):
     """Selecting a marine region shows the locations step; skipping all creates entry."""
     empty_markers_resp = AsyncMock()
-    empty_markers_resp.json = AsyncMock(return_value={
-        "layout": {"primary": {"map": {"modules": [], "markers": []}}}
-    })
+    empty_markers_resp.json = AsyncMock(
+        return_value={"layout": {"primary": {"map": {"modules": [], "markers": []}}}}
+    )
     empty_markers_resp.status = 200
 
     marine_resp = AsyncMock()
-    marine_resp.json = AsyncMock(return_value={
-        "layout": {
-            "search": {
-                "searchLocations": [{"items": [
-                    {"heading": {"label": "Northland", "url": "/marine/regions/northland"}}
-                ]}]
+    marine_resp.json = AsyncMock(
+        return_value={
+            "layout": {
+                "search": {
+                    "searchLocations": [
+                        {
+                            "items": [
+                                {
+                                    "heading": {
+                                        "label": "Northland",
+                                        "url": "/marine/regions/northland",
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
             }
         }
-    })
+    )
     marine_resp.status = 200
 
     session_mock = MagicMock()
     # First call: marine fetch; subsequent calls: tide/boating/surf location fetches
-    session_mock.get = AsyncMock(side_effect=[
-        marine_resp,
-        empty_markers_resp,
-        empty_markers_resp,
-        empty_markers_resp,
-    ])
+    session_mock.get = AsyncMock(
+        side_effect=[
+            marine_resp,
+            empty_markers_resp,
+            empty_markers_resp,
+            empty_markers_resp,
+        ]
+    )
 
     with patch(
         "custom_components.metservice_weather.config_flow.async_get_clientsession",
@@ -101,6 +117,7 @@ async def test_public_with_marine_region(hass, mock_coordinator_refresh):
 # ---------------------------------------------------------------------------
 # Test 7 — duplicate location aborts
 # ---------------------------------------------------------------------------
+
 
 async def test_duplicate_location_aborts(hass, mock_marine_session):
     """Second setup with same location unique_id aborts."""
@@ -140,6 +157,7 @@ async def test_duplicate_location_aborts(hass, mock_marine_session):
 # Test 8 — marine fetch fails gracefully
 # ---------------------------------------------------------------------------
 
+
 async def test_marine_fetch_fails_gracefully(hass, mock_coordinator_refresh):
     """If marine fetch raises an exception, the form still shows with no crash."""
     session_mock = MagicMock()
@@ -159,6 +177,7 @@ async def test_marine_fetch_fails_gracefully(hass, mock_coordinator_refresh):
 # ---------------------------------------------------------------------------
 # Test 9 — reconfigure
 # ---------------------------------------------------------------------------
+
 
 async def test_reconfigure(hass, mock_marine_session):
     """Reconfigure flow pre-fills existing entry data and updates on submit."""
@@ -206,34 +225,48 @@ async def test_reconfigure(hass, mock_marine_session):
 # Test 15 — location fetch exception is swallowed, step still shows
 # ---------------------------------------------------------------------------
 
+
 async def test_locations_fetch_exception_graceful(hass, mock_coordinator_refresh):
     """If one of tide/boating/surf fetches raises, the locations form still shows."""
     marine_resp = AsyncMock()
-    marine_resp.json = AsyncMock(return_value={
-        "layout": {
-            "search": {
-                "searchLocations": [{"items": [
-                    {"heading": {"label": "Northland", "url": "/marine/regions/northland"}}
-                ]}]
+    marine_resp.json = AsyncMock(
+        return_value={
+            "layout": {
+                "search": {
+                    "searchLocations": [
+                        {
+                            "items": [
+                                {
+                                    "heading": {
+                                        "label": "Northland",
+                                        "url": "/marine/regions/northland",
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
             }
         }
-    })
+    )
     marine_resp.status = 200
 
     ok_resp = AsyncMock()
-    ok_resp.json = AsyncMock(return_value={
-        "layout": {"primary": {"map": {"modules": [], "markers": []}}}
-    })
+    ok_resp.json = AsyncMock(
+        return_value={"layout": {"primary": {"map": {"modules": [], "markers": []}}}}
+    )
     ok_resp.status = 200
 
     session_mock = MagicMock()
     # Marine fetch succeeds; tide raises; boating and surf succeed
-    session_mock.get = AsyncMock(side_effect=[
-        marine_resp,
-        Exception("tide fetch failed"),
-        ok_resp,
-        ok_resp,
-    ])
+    session_mock.get = AsyncMock(
+        side_effect=[
+            marine_resp,
+            Exception("tide fetch failed"),
+            ok_resp,
+            ok_resp,
+        ]
+    )
 
     with patch(
         "custom_components.metservice_weather.config_flow.async_get_clientsession",
@@ -253,15 +286,14 @@ async def test_locations_fetch_exception_graceful(hass, mock_coordinator_refresh
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "locations"
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 # ---------------------------------------------------------------------------
 # Test 16 — _marker_url returns empty string on malformed marker
 # ---------------------------------------------------------------------------
+
 
 def test_marker_url_malformed():
     """_marker_url returns '' when the marker dict is missing expected keys."""
@@ -275,22 +307,29 @@ def test_marker_url_malformed():
 # Test 17 — _resolve_url uses action string path when marker URL is empty
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_url_action_string_path(hass):
     """_resolve_url returns the action string when _marker_url returns empty."""
     flow = WeatherFlowHandler()
     flow.hass = hass
 
-    marker = {"label": {"text": "Mangawhai"}, "action": "/marine/regions/northland/tides/locations/mangawhai"}
+    marker = {
+        "label": {"text": "Mangawhai"},
+        "action": "/marine/regions/northland/tides/locations/mangawhai",
+    }
     label_map = {"0": "Mangawhai"}
     locations = [marker]
 
-    result = flow._resolve_url("Mangawhai", label_map, locations, "marine/regions/northland", "tides")
+    result = flow._resolve_url(
+        "Mangawhai", label_map, locations, "marine/regions/northland", "tides"
+    )
     assert result == "/marine/regions/northland/tides/locations/mangawhai"
 
 
 # ---------------------------------------------------------------------------
 # Test 18 — _resolve_url falls back to slug-constructed URL
 # ---------------------------------------------------------------------------
+
 
 def test_resolve_url_fallback_slug(hass):
     """_resolve_url constructs a fallback URL when neither URL nor action is usable."""
@@ -301,13 +340,16 @@ def test_resolve_url_fallback_slug(hass):
     label_map = {"0": "Big Beach"}
     locations = [marker]
 
-    result = flow._resolve_url("Big Beach", label_map, locations, "marine/regions/northland", "surf")
+    result = flow._resolve_url(
+        "Big Beach", label_map, locations, "marine/regions/northland", "surf"
+    )
     assert result == "/marine/regions/northland/surf/locations/big-beach"
 
 
 # ---------------------------------------------------------------------------
 # Test 19 — reconfigure pre-fills existing marine region label
 # ---------------------------------------------------------------------------
+
 
 async def test_reconfigure_prefills_marine_region(hass, mock_coordinator_refresh):
     """Reconfigure of an entry with a marine_region pre-fills the region label."""
@@ -329,15 +371,26 @@ async def test_reconfigure_prefills_marine_region(hass, mock_coordinator_refresh
     existing_entry.add_to_hass(hass)
 
     marine_resp = AsyncMock()
-    marine_resp.json = AsyncMock(return_value={
-        "layout": {
-            "search": {
-                "searchLocations": [{"items": [
-                    {"heading": {"label": "Northland", "url": "/marine/regions/northland"}}
-                ]}]
+    marine_resp.json = AsyncMock(
+        return_value={
+            "layout": {
+                "search": {
+                    "searchLocations": [
+                        {
+                            "items": [
+                                {
+                                    "heading": {
+                                        "label": "Northland",
+                                        "url": "/marine/regions/northland",
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
             }
         }
-    })
+    )
     marine_resp.status = 200
 
     session_mock = MagicMock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.metservice_weather.coordinator import (
@@ -684,7 +683,10 @@ async def test_get_public_weather_unexpected_exception_raises_update_failed(hass
 
 
 async def test_get_public_weather_tomorrow_injection(hass):
-    """Tomorrow's forecast is injected from 7-day data when 2+ days present."""
+    """Tomorrow's forecast is derived by normalize_public_data from the 7-day
+    data (daily_entries[1]) when 2+ days are present — the coordinator no
+    longer injects it directly.
+    """
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
     daily_with_tomorrow = {
@@ -711,7 +713,7 @@ async def test_get_public_weather_tomorrow_injection(hass):
 
     result = await coord.get_public_weather()
     assert result.tomorrow_condition == "cloudy"
-    assert result.tomorrow_temp_high == 17
+    assert result.tomorrow_temp_high == 17.0
     assert result.tomorrow_temp_low == 10
     assert result.tomorrow_description == "Tomorrow cloudy"
 
@@ -854,11 +856,16 @@ async def test_expand_data_urls_exception_sets_none(hass):
 
 
 async def test_get_public_weather_tomorrow_extraction_exception_silenced(hass):
-    """If tomorrow extraction raises (e.g. empty modules list → IndexError), it is silenced (lines 265-266)."""
+    """Tomorrow_* is derived by normalize_public_data, whose exact-path
+    traversal (_get) tolerates a short/empty 7-day payload without raising —
+    when the 7-day data has no days (e.g. empty modules list), tomorrow_*
+    fields simply stay None and get_public_weather still succeeds.
+    """
     import copy
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
-    # modules is explicitly [] — [0] raises IndexError, caught at line 265.
+    # modules is explicitly [] — normalize_public_data's _get returns None
+    # for the out-of-range "0" index instead of raising IndexError.
     # Use a fresh current dict to avoid cross-test mutation of _PUBLIC_CURRENT.
     current_copy = copy.deepcopy(_PUBLIC_CURRENT)
     # Remove any pre-existing tomorrow key so the assertion is meaningful.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,5 @@
 """Tests for WeatherUpdateCoordinator fetch paths, accessors, and error handling."""
+
 from __future__ import annotations
 
 import json
@@ -30,6 +31,7 @@ def _load(name: str) -> dict:
 
 _PUBLIC_CURRENT = _load("napier_public_current.json")
 _PUBLIC_DAILY = _load("napier_public_daily.json")
+
 
 def _make_config(
     tide_url="",
@@ -66,7 +68,9 @@ def _mock_response(data, status=200):
 # Test: properties
 # ---------------------------------------------------------------------------
 
+
 async def test_coordinator_properties(hass):
+    """Coordinator exposes location and disables tides/boating/surf by default."""
     coord = _make_coordinator(hass)
     assert coord.location == "/towns-cities/regions/hawkes-bay/locations/napier"
     assert coord.location_name == "Napier"
@@ -76,6 +80,7 @@ async def test_coordinator_properties(hass):
 
 
 async def test_coordinator_properties_with_urls(hass):
+    """Coordinator enables tides, boating, and surf when their URLs are configured."""
     coord = _make_coordinator(
         hass,
         tide_url="https://example.com/tides",
@@ -92,31 +97,37 @@ async def test_coordinator_properties_with_urls(hass):
 # Test: get_from_dict (DFS)
 # ---------------------------------------------------------------------------
 
+
 async def test_get_from_dict_simple(hass):
+    """get_from_dict resolves a simple nested key path."""
     coord = _make_coordinator(hass)
     data = {"a": {"b": {"c": 42}}}
     assert coord.get_from_dict(data, ["a", "b", "c"]) == 42
 
 
 async def test_get_from_dict_list_traversal(hass):
+    """get_from_dict extracts a field from the first item of a list."""
     coord = _make_coordinator(hass)
     data = {"items": [{"val": 1}, {"val": 2}]}
     assert coord.get_from_dict(data, ["items", "val"]) == 1
 
 
 async def test_get_from_dict_indexed_list(hass):
+    """get_from_dict resolves a numeric string key as a list index."""
     coord = _make_coordinator(hass)
     data = [{"val": 10}, {"val": 20}]
     assert coord.get_from_dict(data, ["1", "val"]) == 20
 
 
 async def test_get_from_dict_missing_key(hass):
+    """get_from_dict returns None when the key path doesn't exist."""
     coord = _make_coordinator(hass)
     data = {"a": 1}
     assert coord.get_from_dict(data, ["b"]) is None
 
 
 async def test_get_from_dict_empty_keys(hass):
+    """get_from_dict returns the original data when no keys are given."""
     coord = _make_coordinator(hass)
     assert coord.get_from_dict({"x": 1}, []) == {"x": 1}
 
@@ -125,27 +136,35 @@ async def test_get_from_dict_empty_keys(hass):
 # Test: _check_errors
 # ---------------------------------------------------------------------------
 
+
 async def test_check_errors_no_errors(hass):
+    """_check_errors does not raise when the response has no errors key."""
     coord = _make_coordinator(hass)
     coord._check_errors("http://x", {"data": 1})  # should not raise
 
 
 async def test_check_errors_empty_errors_list(hass):
+    """_check_errors does not raise when the errors list is empty."""
     coord = _make_coordinator(hass)
     coord._check_errors("http://x", {"errors": []})  # empty list — no raise
 
 
 async def test_check_errors_raises(hass):
+    """_check_errors raises ValueError with the API's error message."""
     coord = _make_coordinator(hass)
     with pytest.raises(ValueError, match="something went wrong"):
-        coord._check_errors("http://x", {"errors": [{"message": "something went wrong"}]})
+        coord._check_errors(
+            "http://x", {"errors": [{"message": "something went wrong"}]}
+        )
 
 
 # ---------------------------------------------------------------------------
 # Test: _parse_pollen_html
 # ---------------------------------------------------------------------------
 
+
 async def test_parse_pollen_html_level_and_plants(hass):
+    """_parse_pollen_html extracts the pollen level and plant types."""
     coord = _make_coordinator(hass)
     html = '<span class="status-high">High</span><br/>Grass, Timothy'
     result = coord._parse_pollen_html(html)
@@ -154,6 +173,7 @@ async def test_parse_pollen_html_level_and_plants(hass):
 
 
 async def test_parse_pollen_html_empty(hass):
+    """_parse_pollen_html returns None level and type for unrecognized HTML."""
     coord = _make_coordinator(hass)
     result = coord._parse_pollen_html("<div>nothing here</div>")
     assert result["level"] is None
@@ -164,30 +184,45 @@ async def test_parse_pollen_html_empty(hass):
 # Test: _format_timestamp
 # ---------------------------------------------------------------------------
 
+
 async def test_format_timestamp(hass):
+    """_format_timestamp converts a local ISO timestamp to UTC."""
     coord = _make_coordinator(hass)
     result = coord._format_timestamp("2024-06-15T12:00:00+12:00")
     assert "2024-06-15" in result
-    assert result.endswith("+00:00") or "Z" in result or "UTC" in result or "00:00" in result
+    assert (
+        result.endswith("+00:00")
+        or "Z" in result
+        or "UTC" in result
+        or "00:00" in result
+    )
 
 
 # ---------------------------------------------------------------------------
 # Test: get_public_weather — happy path
 # ---------------------------------------------------------------------------
 
+
 async def test_get_public_weather_returns_data(hass):
+    """get_public_weather returns typed data including weather warnings."""
     coord = _make_coordinator(hass)
 
-    warnings_data = {"warnings": [
-        {"name": "Strong Wind", "text": "Gale force winds", "threatPeriod": "Tonight"}
-    ]}
+    warnings_data = {
+        "warnings": [
+            {
+                "name": "Strong Wind",
+                "text": "Gale force winds",
+                "threatPeriod": "Tonight",
+            }
+        ]
+    }
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
 
     responses = [
-        _mock_response(_PUBLIC_CURRENT),        # main fetch
-        _mock_response(warnings_data),          # warnings fetch
-        _mock_response(_PUBLIC_DAILY),          # 7-day fetch
-        _mock_response(pollen_data),            # pollen fetch (best-effort)
+        _mock_response(_PUBLIC_CURRENT),  # main fetch
+        _mock_response(warnings_data),  # warnings fetch
+        _mock_response(_PUBLIC_DAILY),  # 7-day fetch
+        _mock_response(pollen_data),  # pollen fetch (best-effort)
     ]
 
     mock_session = MagicMock()
@@ -207,12 +242,14 @@ async def test_get_public_weather_no_warnings(hass):
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
 
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()
@@ -220,6 +257,7 @@ async def test_get_public_weather_no_warnings(hass):
 
 
 async def test_get_public_weather_timeout_raises_update_failed(hass):
+    """get_public_weather raises UpdateFailed when the request times out."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(side_effect=TimeoutError())
@@ -230,6 +268,7 @@ async def test_get_public_weather_timeout_raises_update_failed(hass):
 
 
 async def test_get_public_weather_client_error_raises_update_failed(hass):
+    """get_public_weather raises UpdateFailed on an aiohttp client error."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("conn failed"))
@@ -240,6 +279,7 @@ async def test_get_public_weather_client_error_raises_update_failed(hass):
 
 
 async def test_get_public_weather_none_response_raises_update_failed(hass):
+    """get_public_weather raises UpdateFailed when the main fetch returns no data."""
     coord = _make_coordinator(hass)
     resp = _mock_response(None)
     mock_session = MagicMock()
@@ -251,6 +291,7 @@ async def test_get_public_weather_none_response_raises_update_failed(hass):
 
 
 async def test_get_public_weather_api_error_raises_update_failed(hass):
+    """get_public_weather raises UpdateFailed when the API response contains an error."""
     coord = _make_coordinator(hass)
     error_resp = {"errors": [{"message": "rate limit exceeded"}]}
     mock_session = MagicMock()
@@ -265,9 +306,16 @@ async def test_get_public_weather_api_error_raises_update_failed(hass):
 # Test: _async_update_data dispatches correctly
 # ---------------------------------------------------------------------------
 
+
 async def test_async_update_data_public(hass):
+    """_async_update_data delegates to get_public_weather."""
     coord = _make_coordinator(hass)
-    with patch.object(coord, "get_public_weather", new_callable=AsyncMock, return_value={"current": {}, "daily": {}}) as mock:
+    with patch.object(
+        coord,
+        "get_public_weather",
+        new_callable=AsyncMock,
+        return_value={"current": {}, "daily": {}},
+    ) as mock:
         await coord._async_update_data()
         mock.assert_called_once()
 
@@ -276,13 +324,23 @@ async def test_async_update_data_public(hass):
 # Test: get_pollen_data
 # ---------------------------------------------------------------------------
 
+
 async def test_get_pollen_data_success(hass):
+    """get_pollen_data parses the pollen level from the fetched module."""
     coord = _make_coordinator(hass)
     pollen_html = '<span class="status-low">Low</span><br/>Grass'
     pollen_data = {
-        "layout": {"primary": {"slots": {"main": {"modules": [
-            {"content": [{"iconName": "pollen", "html": pollen_html}]}
-        ]}}}}
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {"content": [{"iconName": "pollen", "html": pollen_html}]}
+                        ]
+                    }
+                }
+            }
+        }
     }
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(pollen_data))
@@ -293,6 +351,7 @@ async def test_get_pollen_data_success(hass):
 
 
 async def test_get_pollen_data_non_200_returns_empty(hass):
+    """get_pollen_data returns empty pollen levels on a non-200 response."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response({}, status=404))
@@ -303,6 +362,7 @@ async def test_get_pollen_data_non_200_returns_empty(hass):
 
 
 async def test_get_pollen_data_exception_returns_empty(hass):
+    """get_pollen_data returns empty pollen levels when the fetch raises."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(side_effect=Exception("network error"))
@@ -316,11 +376,25 @@ async def test_get_pollen_data_exception_returns_empty(hass):
 # Test: get_tides
 # ---------------------------------------------------------------------------
 
+
 async def test_get_tides_success(hass):
+    """get_tides returns the parsed tide entries."""
     tide_data = {
-        "layout": {"primary": {"slots": {"main": {"modules": [
-            {"tideData": [{"time": "06:30", "type": "HIGH", "height": 1.8}]}
-        ]}}}}
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {
+                                "tideData": [
+                                    {"time": "06:30", "type": "HIGH", "height": 1.8}
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
     }
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
     mock_session = MagicMock()
@@ -333,6 +407,7 @@ async def test_get_tides_success(hass):
 
 
 async def test_get_tides_non_200_returns_none(hass):
+    """get_tides returns None on a non-200 response."""
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response({}, status=404))
@@ -343,6 +418,7 @@ async def test_get_tides_non_200_returns_none(hass):
 
 
 async def test_get_tides_none_response_returns_none(hass):
+    """get_tides returns None when the response body is None."""
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(None))
@@ -353,7 +429,10 @@ async def test_get_tides_none_response_returns_none(hass):
 
 
 async def test_get_tides_missing_tidedata_returns_none(hass):
-    tide_data = {"layout": {"primary": {"slots": {"main": {"modules": [{"other": "data"}]}}}}}
+    """get_tides returns None when no module contains tideData."""
+    tide_data = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"other": "data"}]}}}}
+    }
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(tide_data))
@@ -364,6 +443,7 @@ async def test_get_tides_missing_tidedata_returns_none(hass):
 
 
 async def test_get_tides_network_error_returns_none(hass):
+    """get_tides returns None on a network error."""
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("fail"))
@@ -377,15 +457,32 @@ async def test_get_tides_network_error_returns_none(hass):
 # Test: get_boating_data
 # ---------------------------------------------------------------------------
 
+
 async def test_get_boating_data_success(hass):
+    """get_boating_data returns the boating status and forecast text."""
     boating_data = {
-        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
-            {
-                "view": {"text": "Good", "status": "good"},
-                "forecast": {"text": "Calm seas", "issuedAt": "2024-06-15"},
-                "table": {"columns": []},
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {
+                                "days": [
+                                    {
+                                        "view": {"text": "Good", "status": "good"},
+                                        "forecast": {
+                                            "text": "Calm seas",
+                                            "issuedAt": "2024-06-15",
+                                        },
+                                        "table": {"columns": []},
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
             }
-        ]}]}}}}
+        }
     }
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
@@ -398,6 +495,7 @@ async def test_get_boating_data_success(hass):
 
 
 async def test_get_boating_data_non_200_returns_empty(hass):
+    """get_boating_data returns an empty dict on a non-200 response."""
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response({}, status=503))
@@ -407,7 +505,10 @@ async def test_get_boating_data_non_200_returns_empty(hass):
 
 
 async def test_get_boating_data_no_days_returns_empty(hass):
-    boating_data = {"layout": {"primary": {"slots": {"main": {"modules": [{"days": []}]}}}}}
+    """get_boating_data returns an empty dict when the days list is empty."""
+    boating_data = {
+        "layout": {"primary": {"slots": {"main": {"modules": [{"days": []}]}}}}
+    }
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(boating_data))
@@ -417,6 +518,7 @@ async def test_get_boating_data_no_days_returns_empty(hass):
 
 
 async def test_get_boating_data_no_modules_returns_empty(hass):
+    """get_boating_data returns an empty dict when there are no modules."""
     boating_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
@@ -427,6 +529,7 @@ async def test_get_boating_data_no_modules_returns_empty(hass):
 
 
 async def test_get_boating_data_network_error_returns_empty(hass):
+    """get_boating_data returns an empty dict on a network error."""
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
     mock_session.get = AsyncMock(side_effect=aiohttp.ClientError("fail"))
@@ -439,25 +542,36 @@ async def test_get_boating_data_network_error_returns_empty(hass):
 # Test: get_surf_data
 # ---------------------------------------------------------------------------
 
+
 def _surf_marker(path="/marine/regions/northland/surf/locations/waihi-beach"):
     return {
-        "action": {"modules": [{"link": {"url": path}, "value": {
-            "rating": 3,
-            "waveHeight": 1.2,
-            "setFace": 1.5,
-            "swell": {"direction": "NW", "swellHeight": 1.0},
-            "wind": {"direction": "SW", "averageSpeed": 20, "gustSpeed": 30},
-            "period": 8,
-        }}]},
+        "action": {
+            "modules": [
+                {
+                    "link": {"url": path},
+                    "value": {
+                        "rating": 3,
+                        "waveHeight": 1.2,
+                        "setFace": 1.5,
+                        "swell": {"direction": "NW", "swellHeight": 1.0},
+                        "wind": {
+                            "direction": "SW",
+                            "averageSpeed": 20,
+                            "gustSpeed": 30,
+                        },
+                        "period": 8,
+                    },
+                }
+            ]
+        },
         "view": {"text": "Fair"},
     }
 
 
 async def test_get_surf_data_success(hass):
+    """get_surf_data returns the surf rating and conditions for a matching marker."""
     surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
-    surf_data = {
-        "layout": {"primary": {"map": {"markers": [_surf_marker()]}}}
-    }
+    surf_data = {"layout": {"primary": {"map": {"markers": [_surf_marker()]}}}}
     coord = _make_coordinator(hass, surf_url=surf_url)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(surf_data))
@@ -469,6 +583,7 @@ async def test_get_surf_data_success(hass):
 
 
 async def test_get_surf_data_no_matching_marker_returns_empty(hass):
+    """get_surf_data returns an empty dict when no marker matches the surf URL."""
     surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
     surf_data = {"layout": {"primary": {"map": {"markers": []}}}}
     coord = _make_coordinator(hass, surf_url=surf_url)
@@ -480,6 +595,7 @@ async def test_get_surf_data_no_matching_marker_returns_empty(hass):
 
 
 async def test_get_surf_data_non_200_returns_empty(hass):
+    """get_surf_data returns an empty dict on a non-200 response."""
     surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
     coord = _make_coordinator(hass, surf_url=surf_url)
     mock_session = MagicMock()
@@ -490,6 +606,7 @@ async def test_get_surf_data_non_200_returns_empty(hass):
 
 
 async def test_get_surf_data_network_error_returns_empty(hass):
+    """get_surf_data returns an empty dict on a network error."""
     surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
     coord = _make_coordinator(hass, surf_url=surf_url)
     mock_session = MagicMock()
@@ -503,7 +620,9 @@ async def test_get_surf_data_network_error_returns_empty(hass):
 # Test: expand_data_urls
 # ---------------------------------------------------------------------------
 
+
 async def test_expand_data_urls_replaces_node(hass):
+    """expand_data_urls replaces a dataUrl node with the fetched payload."""
     coord = _make_coordinator(hass)
     expanded = {"realData": 42}
     mock_session = MagicMock()
@@ -516,6 +635,7 @@ async def test_expand_data_urls_replaces_node(hass):
 
 
 async def test_expand_data_urls_non_200_sets_none(hass):
+    """expand_data_urls sets the node to None on a non-200 response."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response({}, status=500))
@@ -527,6 +647,7 @@ async def test_expand_data_urls_non_200_sets_none(hass):
 
 
 async def test_expand_data_urls_no_data_url_unchanged(hass):
+    """expand_data_urls leaves data unchanged and makes no requests when there's no dataUrl."""
     coord = _make_coordinator(hass)
     data = {"a": 1, "b": {"c": 2}}
     mock_session = MagicMock()
@@ -539,6 +660,7 @@ async def test_expand_data_urls_no_data_url_unchanged(hass):
 
 
 async def test_expand_data_urls_list(hass):
+    """expand_data_urls expands a dataUrl found inside a list."""
     coord = _make_coordinator(hass)
     expanded = {"val": 99}
     mock_session = MagicMock()
@@ -566,26 +688,41 @@ async def test_expand_data_urls_max_depth_guard(hass):
 # Test: tide/boating/surf injected into public weather fetch
 # ---------------------------------------------------------------------------
 
+
 async def test_get_public_weather_injects_tides(hass):
     """When tide_url is set, tideImport is injected into result_current."""
     coord = _make_coordinator(hass, tide_url="https://example.com/tides")
 
     tide_resp = {
-        "layout": {"primary": {"slots": {"main": {"modules": [
-            {"tideData": [{"type": "HIGH", "time": "06:00", "height": 1.5}]}
-        ]}}}}
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {
+                                "tideData": [
+                                    {"type": "HIGH", "time": "06:00", "height": 1.5}
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
     }
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
 
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-        _mock_response(tide_resp),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+            _mock_response(tide_resp),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()
@@ -595,22 +732,40 @@ async def test_get_public_weather_injects_tides(hass):
 async def test_get_public_weather_injects_boating(hass):
     """When boating_url is set, boating_data is injected into result_current."""
     boating_data_resp = {
-        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
-            {"view": {"text": "Good", "status": "good"}, "forecast": {"text": "Calm", "issuedAt": ""}, "table": {"columns": []}}
-        ]}]}}}}
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {
+                                "days": [
+                                    {
+                                        "view": {"text": "Good", "status": "good"},
+                                        "forecast": {"text": "Calm", "issuedAt": ""},
+                                        "table": {"columns": []},
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
     }
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
 
     coord = _make_coordinator(hass, boating_url="https://example.com/boating")
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-        _mock_response(boating_data_resp),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+            _mock_response(boating_data_resp),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()
@@ -628,13 +783,15 @@ async def test_get_public_weather_injects_surf(hass):
 
     coord = _make_coordinator(hass, surf_url=surf_url)
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-        _mock_response(surf_resp),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+            _mock_response(surf_resp),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()
@@ -645,10 +802,12 @@ async def test_get_public_weather_warnings_none_raises_update_failed(hass):
     """When warnings fetch returns None, UpdateFailed is raised."""
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(None),   # warnings returns None
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(None),  # warnings returns None
+        ]
+    )
     coord._session = mock_session
 
     with pytest.raises(UpdateFailed, match="No warnings data"):
@@ -660,11 +819,13 @@ async def test_get_public_weather_daily_none_raises_update_failed(hass):
     warnings_data = {"warnings": []}
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(None),  # daily returns None
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(None),  # daily returns None
+        ]
+    )
     coord._session = mock_session
 
     with pytest.raises(UpdateFailed, match="No daily forecast"):
@@ -683,32 +844,55 @@ async def test_get_public_weather_unexpected_exception_raises_update_failed(hass
 
 
 async def test_get_public_weather_tomorrow_injection(hass):
-    """Tomorrow's forecast is derived by normalize_public_data from the 7-day
-    data (daily_entries[1]) when 2+ days are present — the coordinator no
-    longer injects it directly.
-    """
+    """Tomorrow's forecast is derived from daily_entries[1] by normalize_public_data, not injected by the coordinator."""
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
     daily_with_tomorrow = {
-        "layout": {"primary": {"slots": {"main": {"modules": [{"days": [
-            {
-                "condition": "fine",
-                "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}],
-            },
-            {
-                "condition": "cloudy",
-                "forecasts": [{"highTemp": 17, "lowTemp": 10, "statement": "Tomorrow cloudy"}],
-            },
-        ]}]}}}}
+        "layout": {
+            "primary": {
+                "slots": {
+                    "main": {
+                        "modules": [
+                            {
+                                "days": [
+                                    {
+                                        "condition": "fine",
+                                        "forecasts": [
+                                            {
+                                                "highTemp": 20,
+                                                "lowTemp": 12,
+                                                "statement": "Today fine",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "condition": "cloudy",
+                                        "forecasts": [
+                                            {
+                                                "highTemp": 17,
+                                                "lowTemp": 10,
+                                                "statement": "Tomorrow cloudy",
+                                            }
+                                        ],
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
     }
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(daily_with_tomorrow),
-        _mock_response(pollen_data),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(daily_with_tomorrow),
+            _mock_response(pollen_data),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()
@@ -735,12 +919,14 @@ async def test_get_public_weather_drying_wet_all_day(hass):
     ]
 
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+        ]
+    )
     coord._session = mock_session
 
     original_get_from_dict = coord.get_from_dict
@@ -754,8 +940,10 @@ async def test_get_public_weather_drying_wet_all_day(hass):
         result = await coord.get_public_weather()
 
     assert result.drying_morning == "Wet all day"
-    assert result.drying_afternoon == "Wet all day"   # mirrored from morning
-    assert result.drying_next_good_day == "Thursday"  # extracted from "Next good day: Thursday"
+    assert result.drying_afternoon == "Wet all day"  # mirrored from morning
+    assert (
+        result.drying_next_good_day == "Thursday"
+    )  # extracted from "Next good day: Thursday"
 
 
 async def test_get_public_weather_drying_exception_silenced(hass):
@@ -766,12 +954,14 @@ async def test_get_public_weather_drying_exception_silenced(hass):
     coord = _make_coordinator(hass)
 
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(_PUBLIC_CURRENT),
-        _mock_response(warnings_data),
-        _mock_response(_PUBLIC_DAILY),
-        _mock_response(pollen_data),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(_PUBLIC_CURRENT),
+            _mock_response(warnings_data),
+            _mock_response(_PUBLIC_DAILY),
+            _mock_response(pollen_data),
+        ]
+    )
     coord._session = mock_session
 
     def patched_get_from_dict(data, keys):
@@ -789,6 +979,7 @@ async def test_get_public_weather_drying_exception_silenced(hass):
 # ---------------------------------------------------------------------------
 # Test: exception paths in marine helpers
 # ---------------------------------------------------------------------------
+
 
 async def test_get_tides_unexpected_exception_returns_none(hass):
     """Unexpected exception in get_tides returns None (lines 366-368)."""
@@ -827,9 +1018,7 @@ async def test_get_surf_data_bad_marker_skipped(hass):
     surf_url = "https://www.metservice.com/publicData/webdata/marine/regions/northland/surf/locations/waihi-beach"
     bad_marker = {}  # missing 'action' key → KeyError
     good_marker = _surf_marker()
-    surf_data = {
-        "layout": {"primary": {"map": {"markers": [bad_marker, good_marker]}}}
-    }
+    surf_data = {"layout": {"primary": {"map": {"markers": [bad_marker, good_marker]}}}}
     coord = _make_coordinator(hass, surf_url=surf_url)
     mock_session = MagicMock()
     mock_session.get = AsyncMock(return_value=_mock_response(surf_data))
@@ -842,6 +1031,7 @@ async def test_get_surf_data_bad_marker_skipped(hass):
 # ---------------------------------------------------------------------------
 # Test: expand_data_urls exception path
 # ---------------------------------------------------------------------------
+
 
 async def test_expand_data_urls_exception_sets_none(hass):
     """When session.get raises (not timeout/client), parent key is set to None (lines 636-639)."""
@@ -856,12 +1046,9 @@ async def test_expand_data_urls_exception_sets_none(hass):
 
 
 async def test_get_public_weather_tomorrow_extraction_exception_silenced(hass):
-    """Tomorrow_* is derived by normalize_public_data, whose exact-path
-    traversal (_get) tolerates a short/empty 7-day payload without raising —
-    when the 7-day data has no days (e.g. empty modules list), tomorrow_*
-    fields simply stay None and get_public_weather still succeeds.
-    """
+    """Tomorrow_* fields stay None instead of raising when the 7-day payload has no days."""
     import copy
+
     warnings_data = {"warnings": []}
     pollen_data = {"layout": {"primary": {"slots": {"main": {"modules": []}}}}}
     # modules is explicitly [] — normalize_public_data's _get returns None
@@ -874,12 +1061,14 @@ async def test_get_public_weather_tomorrow_extraction_exception_silenced(hass):
 
     coord = _make_coordinator(hass)
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=[
-        _mock_response(current_copy),
-        _mock_response(warnings_data),
-        _mock_response(daily_bad),
-        _mock_response(pollen_data),
-    ])
+    mock_session.get = AsyncMock(
+        side_effect=[
+            _mock_response(current_copy),
+            _mock_response(warnings_data),
+            _mock_response(daily_bad),
+            _mock_response(pollen_data),
+        ]
+    )
     coord._session = mock_session
 
     result = await coord.get_public_weather()

--- a/tests/test_coordinator_data.py
+++ b/tests/test_coordinator_data.py
@@ -8,6 +8,7 @@ sane range.
 Run from project root (WSL):
     pytest tests/test_coordinator_data.py -v
 """
+
 from __future__ import annotations
 
 import json
@@ -62,56 +63,69 @@ def rural_coord(kumeu_data):
 
 
 class TestCurrentConditions:
+    """Contract tests for current-conditions fields from the Napier fixture."""
+
     def test_temperature_is_numeric(self, coord):
+        """Temperature is numeric and within a plausible range."""
         val = coord.data.temperature
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert -20 <= val <= 50
 
     def test_feels_like_is_numeric(self, coord):
+        """Feels-like temperature is numeric and within a plausible range."""
         val = coord.data.feels_like
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert -30 <= val <= 60
 
     def test_humidity_is_int_in_range(self, coord):
+        """Humidity is an int between 0 and 100."""
         val = coord.data.humidity
         assert isinstance(val, int), f"Expected int, got {val!r}"
         assert 0 <= val <= 100
 
     def test_pressure_is_numeric(self, coord):
+        """Pressure is numeric and within a plausible range."""
         val = coord.data.pressure
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert 870 <= val <= 1085
 
     def test_wind_speed_is_numeric(self, coord):
+        """Wind speed is a non-negative number."""
         val = coord.data.wind_speed
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert val >= 0
 
     def test_wind_gust_is_numeric(self, coord):
+        """Wind gust is a non-negative number."""
         val = coord.data.wind_gust
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert val >= 0
 
     def test_wind_direction_is_string(self, coord):
+        """Wind direction is a non-empty string."""
         val = coord.data.wind_direction
         assert isinstance(val, str), f"Expected str, got {val!r}"
         assert len(val) >= 1
 
     def test_condition_is_string(self, coord):
+        """Condition is a non-empty string."""
         val = coord.data.condition
         assert isinstance(val, str), f"Expected str, got {val!r}"
         assert len(val) > 0
 
     def test_rainfall_is_numeric(self, coord):
+        """Rainfall is a non-negative number."""
         val = coord.data.rainfall
         assert isinstance(val, (int, float)), f"Expected numeric, got {val!r}"
         assert val >= 0
 
     def test_uv_index_is_string_or_none(self, coord):
+        """UV index is a string or None."""
         val = coord.data.uv_index
         assert isinstance(val, str) or val is None
 
     def test_location_name_is_string(self, coord):
+        """Location name is a non-empty string."""
         val = coord.data.location_name
         assert isinstance(val, str)
         assert len(val) > 0
@@ -123,8 +137,19 @@ class TestCurrentConditions:
 
 
 class TestBreakdown:
-    @pytest.mark.parametrize("attr", ["breakdown_morning", "breakdown_afternoon", "breakdown_evening", "breakdown_overnight"])
+    """Contract tests for the sub-day breakdown fields."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "breakdown_morning",
+            "breakdown_afternoon",
+            "breakdown_evening",
+            "breakdown_overnight",
+        ],
+    )
     def test_breakdown_condition_is_string(self, coord, attr):
+        """Each breakdown period's condition is a string or None."""
         val = getattr(coord.data, attr)
         assert isinstance(val, str) or val is None
 
@@ -135,35 +160,45 @@ class TestBreakdown:
 
 
 class TestInjectedFields:
+    """Contract tests for fields injected or derived by the coordinator."""
+
     def test_weather_warnings_is_string(self, coord):
+        """Weather warnings value is a string."""
         val = coord.data.weather_warnings
         assert isinstance(val, str)
 
     def test_tomorrow_condition_is_string(self, coord):
+        """Tomorrow's condition is a string or None."""
         val = coord.data.tomorrow_condition
         assert isinstance(val, str) or val is None
 
     def test_tomorrow_temp_high_is_present(self, coord):
+        """Tomorrow's high temperature is present."""
         val = coord.data.tomorrow_temp_high
         assert val is not None
 
     def test_tomorrow_temp_low_is_present(self, coord):
+        """Tomorrow's low temperature is present."""
         val = coord.data.tomorrow_temp_low
         assert val is not None
 
     def test_tomorrow_description_is_string(self, coord):
+        """Tomorrow's description is a string or None."""
         val = coord.data.tomorrow_description
         assert isinstance(val, str) or val is None
 
     def test_drying_morning_is_string(self, coord):
+        """Morning drying index is a string or None."""
         val = coord.data.drying_morning
         assert isinstance(val, str) or val is None
 
     def test_drying_afternoon_is_string(self, coord):
+        """Afternoon drying index is a string or None."""
         val = coord.data.drying_afternoon
         assert isinstance(val, str) or val is None
 
     def test_drying_next_good_day_is_string(self, coord):
+        """Next good drying day is a string or None."""
         val = coord.data.drying_next_good_day
         assert isinstance(val, str) or val is None
 
@@ -174,11 +209,15 @@ class TestInjectedFields:
 
 
 class TestPollen:
+    """Contract tests for pollen fields."""
+
     def test_pollen_level_is_string_or_none(self, coord):
+        """Pollen level is a string or None."""
         val = coord.data.pollen_level
         assert isinstance(val, str) or val is None
 
     def test_pollen_type_is_string_or_none(self, coord):
+        """Pollen type is a string or None."""
         val = coord.data.pollen_type
         assert isinstance(val, str) or val is None
 
@@ -189,23 +228,30 @@ class TestPollen:
 
 
 class TestSunMoon:
+    """Contract tests for sun and moon fields."""
+
     def test_sunrise_is_string(self, coord):
+        """Sunrise is a string or None."""
         val = coord.data.sunrise
         assert isinstance(val, str) or val is None
 
     def test_sunset_is_string(self, coord):
+        """Sunset is a string or None."""
         val = coord.data.sunset
         assert isinstance(val, str) or val is None
 
     def test_moon_phase_is_string(self, coord):
+        """Moon phase is a string or None."""
         val = coord.data.moon_phase
         assert isinstance(val, str) or val is None
 
     def test_moonrise_is_string(self, coord):
+        """Moonrise is a string or None."""
         val = coord.data.moonrise
         assert isinstance(val, str) or val is None
 
     def test_moonset_is_string(self, coord):
+        """Moonset is a string or None."""
         val = coord.data.moonset
         assert isinstance(val, str) or val is None
 
@@ -216,11 +262,15 @@ class TestSunMoon:
 
 
 class TestFireWeather:
+    """Contract tests for fire weather fields."""
+
     def test_fire_danger_is_string_or_none(self, coord):
+        """Fire danger is a string or None."""
         val = coord.data.fire_danger
         assert isinstance(val, str) or val is None
 
     def test_fire_season_is_string_or_none(self, coord):
+        """Fire season is a string or None."""
         val = coord.data.fire_season
         assert isinstance(val, str) or val is None
 
@@ -231,22 +281,28 @@ class TestFireWeather:
 
 
 class TestHourlyData:
+    """Contract tests for the hourly forecast fields."""
+
     def test_hourly_entries_is_list(self, coord):
+        """Hourly entries is a non-empty list."""
         val = coord.data.hourly_entries
         assert isinstance(val, list)
         assert len(val) > 0
 
     def test_hourly_obs_is_positive_int(self, coord):
+        """Hourly observation count is a positive int."""
         val = coord.data.hourly_obs
         assert isinstance(val, int)
         assert val > 0
 
     def test_hourly_skip_is_non_negative_int(self, coord):
+        """Hourly skip offset is a non-negative int."""
         val = coord.data.hourly_skip
         assert isinstance(val, int)
         assert val >= 0
 
     def test_hourly_entry_has_required_keys(self, coord):
+        """Current hourly entry has a datetime and a temperature or rainfall value."""
         entries = coord.data.hourly_entries
         skip = coord.data.hourly_skip
         entry = entries[skip]
@@ -261,37 +317,51 @@ class TestHourlyData:
 
 
 class TestDailyForecast:
+    """Contract tests for the daily forecast fields."""
+
     def test_num_days_is_positive(self, coord):
+        """Number of daily entries is between 1 and 14."""
         num_days = len(coord.data.daily_entries)
         assert isinstance(num_days, int)
         assert 1 <= num_days <= 14
 
     def test_day0_condition_is_string(self, coord):
+        """Day 0 condition is a string or None."""
         val = coord.data.daily_entries[0].condition
         assert isinstance(val, str) or val is None
 
     def test_day0_temp_high_is_present(self, coord):
+        """Day 0 high temperature is present."""
         val = coord.data.daily_entries[0].temp_high
         assert val is not None
 
     def test_day0_temp_low_is_present(self, coord):
+        """Day 0 low temperature is present."""
         val = coord.data.daily_entries[0].temp_low
         assert val is not None
 
     def test_day0_datetime_is_string(self, coord):
+        """Day 0 datetime is a string or None."""
         val = coord.data.daily_entries[0].datetime
         assert isinstance(val, str) or val is None
 
     def test_day0_description_is_string_or_none(self, coord):
+        """Day 0 description is a string or None."""
         val = coord.data.daily_entries[0].description
         assert isinstance(val, str) or val is None
 
     def test_all_days_have_condition(self, coord):
-        missing = [i for i, d in enumerate(coord.data.daily_entries) if d.condition is None]
+        """Every daily entry has a condition set."""
+        missing = [
+            i for i, d in enumerate(coord.data.daily_entries) if d.condition is None
+        ]
         assert not missing, f"Days missing condition: {missing}"
 
     def test_all_days_have_high_temp(self, coord):
-        missing = [i for i, d in enumerate(coord.data.daily_entries) if d.temp_high is None]
+        """Every daily entry has a high temperature set."""
+        missing = [
+            i for i, d in enumerate(coord.data.daily_entries) if d.temp_high is None
+        ]
         assert not missing, f"Days missing temp_high: {missing}"
 
 
@@ -301,25 +371,34 @@ class TestDailyForecast:
 
 
 class TestRuralContract:
+    """Contract tests for the rural (no weather station) Kumeu fixture."""
+
     def test_temperature_is_none(self, rural_coord):
+        """Rural location has no current temperature."""
         assert rural_coord.data.temperature is None
 
     def test_wind_speed_is_none(self, rural_coord):
+        """Rural location has no current wind speed."""
         assert rural_coord.data.wind_speed is None
 
     def test_temp_today_high_is_float(self, rural_coord):
+        """Rural location's today high temperature is a float."""
         assert isinstance(rural_coord.data.temp_today_high, float)
 
     def test_tomorrow_temp_high_is_present(self, rural_coord):
+        """Rural location's tomorrow high temperature is present."""
         assert rural_coord.data.tomorrow_temp_high is not None
 
     def test_all_daily_entries_have_temp_high_and_description(self, rural_coord):
+        """Every rural daily entry has a high temperature and description."""
         for i, d in enumerate(rural_coord.data.daily_entries):
             assert d.temp_high is not None, f"day {i} missing temp_high"
             assert d.description is not None, f"day {i} missing description"
 
     def test_is_rural_true(self, rural_coord):
+        """Rural location's is_rural flag is True."""
         assert rural_coord.data.is_rural is True
 
     def test_has_observations_false(self, rural_coord):
+        """Rural location's has_observations flag is False."""
         assert rural_coord.data.has_observations is False

--- a/tests/test_coordinator_data.py
+++ b/tests/test_coordinator_data.py
@@ -40,6 +40,22 @@ def coord(napier_data):
     return c
 
 
+@pytest.fixture(scope="module")
+def kumeu_data():
+    """Load the Kumeu (rural) public fixtures once for the whole module."""
+    current = json.loads((FIXTURES / "kumeu_public_current.json").read_text())
+    daily = json.loads((FIXTURES / "kumeu_public_daily.json").read_text())
+    return {"current": current, "daily": daily}
+
+
+@pytest.fixture
+def rural_coord(kumeu_data):
+    """Return a coordinator with normalised rural fixture data set, without touching HA framework."""
+    c = object.__new__(WeatherUpdateCoordinator)
+    c.data = normalize_public_data(kumeu_data["current"], kumeu_data["daily"])
+    return c
+
+
 # ---------------------------------------------------------------------------
 # Current-conditions sensors
 # ---------------------------------------------------------------------------
@@ -277,3 +293,33 @@ class TestDailyForecast:
     def test_all_days_have_high_temp(self, coord):
         missing = [i for i, d in enumerate(coord.data.daily_entries) if d.temp_high is None]
         assert not missing, f"Days missing temp_high: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Rural contract — Kumeu (no weather station, no breakdown, isRural)
+# ---------------------------------------------------------------------------
+
+
+class TestRuralContract:
+    def test_temperature_is_none(self, rural_coord):
+        assert rural_coord.data.temperature is None
+
+    def test_wind_speed_is_none(self, rural_coord):
+        assert rural_coord.data.wind_speed is None
+
+    def test_temp_today_high_is_float(self, rural_coord):
+        assert isinstance(rural_coord.data.temp_today_high, float)
+
+    def test_tomorrow_temp_high_is_present(self, rural_coord):
+        assert rural_coord.data.tomorrow_temp_high is not None
+
+    def test_all_daily_entries_have_temp_high_and_description(self, rural_coord):
+        for i, d in enumerate(rural_coord.data.daily_entries):
+            assert d.temp_high is not None, f"day {i} missing temp_high"
+            assert d.description is not None, f"day {i} missing description"
+
+    def test_is_rural_true(self, rural_coord):
+        assert rural_coord.data.is_rural is True
+
+    def test_has_observations_false(self, rural_coord):
+        assert rural_coord.data.has_observations is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 """Tests for async_setup_entry and async_unload_entry in __init__.py."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -31,6 +32,7 @@ def _make_entry(data: dict) -> MockConfigEntry:
 # ---------------------------------------------------------------------------
 # Test: async_setup_entry and async_unload_entry (public API)
 # ---------------------------------------------------------------------------
+
 
 async def test_setup_and_unload_public(hass):
     """Entry sets up correctly and unloads cleanly for the public API path."""
@@ -92,7 +94,9 @@ async def test_setup_first_refresh_failure_raises(hass):
 
 async def test_runtime_data_set_after_setup(hass):
     """Coordinator is accessible via entry.runtime_data after setup."""
-    from custom_components.metservice_weather.coordinator import WeatherUpdateCoordinator
+    from custom_components.metservice_weather.coordinator import (
+        WeatherUpdateCoordinator,
+    )
 
     entry = _make_entry(_PUBLIC_ENTRY_DATA)
     entry.add_to_hass(hass)

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,4 +1,5 @@
 """Tests for coordinator_types: _get, normalizer, and dataclass structure."""
+
 from __future__ import annotations
 
 import json
@@ -22,6 +23,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 @pytest.fixture(scope="module")
 def napier():
+    """Build normalized MetServicePublicData from the Napier (towns-cities) fixtures."""
     current = json.loads((FIXTURES / "napier_public_current.json").read_text())
     daily = json.loads((FIXTURES / "napier_public_daily.json").read_text())
     return normalize_public_data(current, daily)
@@ -29,6 +31,7 @@ def napier():
 
 @pytest.fixture(scope="module")
 def kumeu():
+    """Build normalized MetServicePublicData from the Kumeu (rural) fixtures."""
     current = json.loads((FIXTURES / "kumeu_public_current.json").read_text())
     daily = json.loads((FIXTURES / "kumeu_public_daily.json").read_text())
     return normalize_public_data(current, daily)
@@ -38,48 +41,59 @@ def kumeu():
 # _get — exact-path traversal
 # ---------------------------------------------------------------------------
 
+
 def test_get_simple_dict():
+    """_get returns the value at a simple single-key path."""
     assert _get({"a": 1}, "a") == 1
 
 
 def test_get_nested():
+    """_get traverses nested dict keys."""
     assert _get({"a": {"b": 42}}, "a", "b") == 42
 
 
 def test_get_list_index():
+    """_get indexes into a list using a string index."""
     assert _get(["x", "y", "z"], "1") == "y"
 
 
 def test_get_mixed():
+    """_get traverses a mix of dict keys and list indices."""
     data = {"items": [{"val": 10}, {"val": 20}]}
     assert _get(data, "items", "1", "val") == 20
 
 
 def test_get_missing_key_returns_none():
+    """_get returns None for a missing dict key."""
     assert _get({"a": 1}, "b") is None
 
 
 def test_get_out_of_range_returns_none():
+    """_get returns None for a list index out of range."""
     assert _get([1, 2], "5") is None
 
 
 def test_get_none_data_returns_none():
+    """_get returns None when data is None."""
     assert _get(None, "a") is None
 
 
 def test_get_non_dict_non_list_returns_none():
+    """_get returns None when data is neither a dict nor a list."""
     assert _get(42, "a") is None
 
 
 def test_get_empty_path_returns_data():
+    """_get with an empty path returns the data unchanged."""
     data = {"x": 1}
     assert _get(data) == data
 
 
 def test_get_does_not_search_depth_first():
+    """_get matches only the exact path, not a depth-first search."""
     # DFS would find "val" anywhere in the tree; exact-path must not.
     data = {"level1": {"other": {"val": 999}}, "val": 42}
-    assert _get(data, "val") == 42          # top-level hit only
+    assert _get(data, "val") == 42  # top-level hit only
     assert _get(data, "level1", "val") is None  # "val" not a direct child of level1
 
 
@@ -87,22 +101,27 @@ def test_get_does_not_search_depth_first():
 # _safe_float / _safe_int
 # ---------------------------------------------------------------------------
 
+
 def test_safe_float_numeric():
+    """_safe_float converts numeric strings and numbers to float."""
     assert _safe_float("18.5") == 18.5
     assert _safe_float(18) == 18.0
 
 
 def test_safe_float_invalid():
+    """_safe_float returns None for None or non-numeric strings."""
     assert _safe_float(None) is None
     assert _safe_float("n/a") is None
 
 
 def test_safe_int_numeric():
+    """_safe_int converts numeric strings and floats to int."""
     assert _safe_int("5") == 5
     assert _safe_int(5.9) == 5
 
 
 def test_safe_int_invalid():
+    """_safe_int returns None for None or non-numeric strings."""
     assert _safe_int(None) is None
     assert _safe_int("bad") is None
 
@@ -111,74 +130,90 @@ def test_safe_int_invalid():
 # normalize_public_data — against Napier fixture
 # ---------------------------------------------------------------------------
 
+
 def test_returns_correct_type(napier):
+    """normalize_public_data returns a MetServicePublicData instance."""
     assert isinstance(napier, MetServicePublicData)
 
 
 def test_temperature_is_float(napier):
+    """Normalized temperature is a float within a plausible range."""
     assert isinstance(napier.temperature, float)
     assert -20 <= napier.temperature <= 50
 
 
 def test_humidity_is_int(napier):
+    """Normalized humidity is an int within 0-100."""
     assert isinstance(napier.humidity, int)
     assert 0 <= napier.humidity <= 100
 
 
 def test_wind_direction_is_string(napier):
+    """Normalized wind_direction is a string."""
     assert isinstance(napier.wind_direction, str)
 
 
 def test_condition_is_string(napier):
+    """Normalized condition is a string."""
     assert isinstance(napier.condition, str)
 
 
 def test_weather_warnings_is_string(napier):
+    """Normalized weather_warnings is a string."""
     assert isinstance(napier.weather_warnings, str)
 
 
 def test_pollen_level_present(napier):
+    """Normalized pollen_level is populated from the Napier fixture."""
     assert napier.pollen_level is not None
 
 
 def test_tomorrow_fields_present(napier):
+    """Normalized tomorrow_condition and tomorrow_temp_high are populated."""
     assert napier.tomorrow_condition is not None
     assert napier.tomorrow_temp_high is not None
 
 
 def test_hourly_entries_is_list(napier):
+    """Normalized hourly_entries is a non-empty list of HourlyEntry."""
     assert isinstance(napier.hourly_entries, list)
     assert len(napier.hourly_entries) > 0
     assert isinstance(napier.hourly_entries[0], HourlyEntry)
 
 
 def test_daily_entries_is_list(napier):
+    """Normalized daily_entries is a list of 1-14 DailyEntry items."""
     assert isinstance(napier.daily_entries, list)
     assert 1 <= len(napier.daily_entries) <= 14
     assert isinstance(napier.daily_entries[0], DailyEntry)
 
 
 def test_all_daily_entries_have_condition(napier):
+    """Every normalized daily entry has a condition."""
     missing = [i for i, d in enumerate(napier.daily_entries) if d.condition is None]
     assert not missing, f"Days missing condition: {missing}"
 
 
 def test_all_daily_entries_have_temp_high(napier):
+    """Every normalized daily entry has a temp_high."""
     missing = [i for i, d in enumerate(napier.daily_entries) if d.temp_high is None]
     assert not missing, f"Days missing temp_high: {missing}"
 
 
 def test_sunrise_is_string(napier):
+    """Normalized sunrise is a string."""
     assert isinstance(napier.sunrise, str)
 
 
 def test_moon_phase_is_string(napier):
+    """Normalized moon_phase is a string."""
     assert isinstance(napier.moon_phase, str)
 
 
 # ---------------------------------------------------------------------------
 # normalize_public_data — marine field extraction
 # ---------------------------------------------------------------------------
+
 
 def test_marine_fields_none_when_absent():
     """With no marine data injected, all marine fields are None."""
@@ -192,6 +227,7 @@ def test_marine_fields_none_when_absent():
 
 
 def test_tides_extracted_from_tide_import():
+    """Tides are extracted from the tideImport key on the current payload."""
     tides = [{"type": "HIGH", "time": "06:30", "height": 1.8}]
     current = {
         "weather_warnings": "No warnings",
@@ -202,6 +238,7 @@ def test_tides_extracted_from_tide_import():
 
 
 def test_boating_extracted_from_boating_data():
+    """Boating status and forecast text are extracted from boating_data."""
     current = {
         "weather_warnings": "No warnings",
         "boating_data": {
@@ -216,6 +253,7 @@ def test_boating_extracted_from_boating_data():
 
 
 def test_surf_extracted_from_surf_data():
+    """Surf conditions and rating are extracted from surf_data."""
     current = {
         "weather_warnings": "No warnings",
         "surf_data": {
@@ -233,6 +271,7 @@ def test_surf_extracted_from_surf_data():
 # normalize_public_data — edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_empty_dicts_returns_defaults():
     """normalize_public_data must not raise on completely empty input."""
     result = normalize_public_data({}, {})
@@ -246,12 +285,15 @@ def test_empty_dicts_returns_defaults():
 # _scan_forecasts — forecast entry scanning
 # ---------------------------------------------------------------------------
 
+
 def test_scan_forecasts_towns_shape_prefers_forecasts_entry():
+    """_scan_forecasts prefers the value from the forecasts entry over the day level."""
     day = {"forecasts": [{"highTemp": 16}], "highTemp": 15}
     assert _scan_forecasts(day, "highTemp") == 16
 
 
 def test_scan_forecasts_rural_shape_finds_second_entry():
+    """_scan_forecasts finds the field in the second forecasts entry for the rural shape."""
     day = {
         "forecasts": [
             {"statement": "regional", "title": "Region"},
@@ -264,25 +306,30 @@ def test_scan_forecasts_rural_shape_finds_second_entry():
 
 
 def test_scan_forecasts_day_level_only():
+    """_scan_forecasts falls back to the day level when forecasts is absent."""
     day = {"highTemp": 12}
     assert _scan_forecasts(day, "highTemp") == 12
 
 
 def test_scan_forecasts_none_in_forecasts_falls_through_to_day_level():
+    """_scan_forecasts falls back to the day level when forecasts entries are None."""
     day = {"forecasts": [{"highTemp": None}], "highTemp": 9}
     assert _scan_forecasts(day, "highTemp") == 9
 
 
 def test_scan_forecasts_absent_everywhere_returns_none():
+    """_scan_forecasts returns None when the field is absent everywhere."""
     assert _scan_forecasts({}, "highTemp") is None
 
 
 def test_scan_forecasts_non_dict_day_returns_none():
+    """_scan_forecasts returns None when day is not a dict."""
     assert _scan_forecasts(None, "highTemp") is None
     assert _scan_forecasts(42, "highTemp") is None
 
 
 def test_scan_forecasts_non_dict_forecast_entries_skipped():
+    """_scan_forecasts skips non-dict entries in the forecasts list."""
     day = {"forecasts": ["junk", {"highTemp": 5}]}
     assert _scan_forecasts(day, "highTemp") == 5
 
@@ -291,16 +338,24 @@ def test_scan_forecasts_non_dict_forecast_entries_skipped():
 # daily entry shape heuristics
 # ---------------------------------------------------------------------------
 
+
 def _daily_payload(days):
     return {"layout": {"primary": {"slots": {"main": {"modules": [{"days": days}]}}}}}
 
 
 def test_daily_entry_towns_shape():
+    """Towns-shape daily entry populates temps, description, and rain probabilities from the forecasts entry."""
     day = {
         "date": "2024-06-15",
         "condition": "fine",
         "forecasts": [
-            {"highTemp": 22, "lowTemp": 12, "statement": "Sunny day", "rainFall1": 30.0, "rainFall10": 5.0}
+            {
+                "highTemp": 22,
+                "lowTemp": 12,
+                "statement": "Sunny day",
+                "rainFall1": 30.0,
+                "rainFall10": 5.0,
+            }
         ],
         "highTemp": 22,
         "lowTemp": 12,
@@ -316,12 +371,19 @@ def test_daily_entry_towns_shape():
 
 
 def test_daily_entry_rural_shape():
+    """Rural daily entries populate temps from the location forecasts entry."""
     day = {
         "date": "2024-06-15",
         "condition": "cloudy",
         "forecasts": [
             {"statement": "Regional cloudy", "title": "Region"},
-            {"highTemp": 18, "lowTemp": 9, "rainFall1": 40.0, "rainFall10": 10.0, "statement": None},
+            {
+                "highTemp": 18,
+                "lowTemp": 9,
+                "rainFall1": 40.0,
+                "rainFall10": 10.0,
+                "statement": None,
+            },
         ],
         "highTemp": 18,
         "lowTemp": 9,
@@ -337,7 +399,14 @@ def test_daily_entry_rural_shape():
 
 
 def test_daily_entry_day_level_only():
-    day = {"date": "2024-06-15", "condition": "fine", "highTemp": 20, "lowTemp": 10, "statement": "Fine day"}
+    """Daily entry falls back to day-level temps and statement when forecasts is absent."""
+    day = {
+        "date": "2024-06-15",
+        "condition": "fine",
+        "highTemp": 20,
+        "lowTemp": 10,
+        "statement": "Fine day",
+    }
     result = normalize_public_data({}, _daily_payload([day]))
     entry = result.daily_entries[0]
     assert entry.temp_high == 20.0
@@ -346,6 +415,7 @@ def test_daily_entry_day_level_only():
 
 
 def test_daily_entry_empty_day():
+    """An empty day dict normalizes to a DailyEntry with all fields None."""
     result = normalize_public_data({}, _daily_payload([{}]))
     entry = result.daily_entries[0]
     assert entry.datetime is None
@@ -358,6 +428,7 @@ def test_daily_entry_empty_day():
 
 
 def test_daily_entry_rain_fields_absent_is_none_not_zero():
+    """Absent rain fields normalize to None rather than zero."""
     day = {"highTemp": 15, "lowTemp": 8, "statement": "no rain data"}
     result = normalize_public_data({}, _daily_payload([day]))
     entry = result.daily_entries[0]
@@ -366,6 +437,7 @@ def test_daily_entry_rain_fields_absent_is_none_not_zero():
 
 
 def test_daily_entry_string_temps_coerced_to_float():
+    """String temperature values are coerced to float."""
     day = {"forecasts": [{"highTemp": "16"}]}
     result = normalize_public_data({}, _daily_payload([day]))
     entry = result.daily_entries[0]
@@ -377,20 +449,40 @@ def test_daily_entry_string_temps_coerced_to_float():
 # tomorrow derivation
 # ---------------------------------------------------------------------------
 
+
 def test_tomorrow_derived_from_day_index_1():
+    """Tomorrow fields are derived from daily_entries index 1."""
     days = [
-        {"condition": "fine", "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}]},
-        {"condition": "cloudy", "forecasts": [{"highTemp": 17, "lowTemp": 10, "statement": "Tomorrow cloudy"}]},
+        {
+            "condition": "fine",
+            "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}],
+        },
+        {
+            "condition": "cloudy",
+            "forecasts": [
+                {"highTemp": 17, "lowTemp": 10, "statement": "Tomorrow cloudy"}
+            ],
+        },
     ]
     result = normalize_public_data({}, _daily_payload(days))
     assert result.tomorrow_condition == "cloudy"
-    assert result.tomorrow_temp_high == 17.0 and isinstance(result.tomorrow_temp_high, float)
-    assert result.tomorrow_temp_low == 10.0 and isinstance(result.tomorrow_temp_low, float)
+    assert result.tomorrow_temp_high == 17.0 and isinstance(
+        result.tomorrow_temp_high, float
+    )
+    assert result.tomorrow_temp_low == 10.0 and isinstance(
+        result.tomorrow_temp_low, float
+    )
     assert result.tomorrow_description == "Tomorrow cloudy"
 
 
 def test_tomorrow_none_with_only_one_day():
-    days = [{"condition": "fine", "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}]}]
+    """Tomorrow fields are None when only one day of forecast data is present."""
+    days = [
+        {
+            "condition": "fine",
+            "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}],
+        }
+    ]
     result = normalize_public_data({}, _daily_payload(days))
     assert result.tomorrow_condition is None
     assert result.tomorrow_temp_high is None
@@ -399,6 +491,7 @@ def test_tomorrow_none_with_only_one_day():
 
 
 def test_tomorrow_none_with_empty_daily_dict():
+    """Tomorrow fields are None when the daily payload is empty."""
     result = normalize_public_data({}, {})
     assert result.tomorrow_condition is None
     assert result.tomorrow_temp_high is None
@@ -410,16 +503,24 @@ def test_tomorrow_none_with_empty_daily_dict():
 # today's high/low fallback
 # ---------------------------------------------------------------------------
 
+
 def _current_payload(obs=None, days=None):
     left = [{"observations": obs}] if obs is not None else []
     main = [{"days": days}] if days is not None else []
-    return {"layout": {"primary": {"slots": {
-        "left-major": {"modules": left},
-        "main": {"modules": main},
-    }}}}
+    return {
+        "layout": {
+            "primary": {
+                "slots": {
+                    "left-major": {"modules": left},
+                    "main": {"modules": main},
+                }
+            }
+        }
+    }
 
 
 def test_today_high_low_prefers_observations():
+    """Today's high/low prefer the observations block over day-level forecast temps."""
     obs = {"temperature": [{"high": 25.0, "low": 15.0, "current": 20.0}]}
     days = [{"highTemp": 30, "lowTemp": 10}]
     result = normalize_public_data(_current_payload(obs=obs, days=days), {})
@@ -436,6 +537,7 @@ def test_today_high_low_falls_back_to_day_level_when_no_observations():
 
 
 def test_today_high_low_falls_back_to_forecasts_entry_rural_shape():
+    """Today's high/low fall back to the second forecasts entry for the rural shape."""
     days = [{"forecasts": [{"statement": "regional"}, {"highTemp": 16, "lowTemp": 6}]}]
     result = normalize_public_data(_current_payload(days=days), {})
     assert result.temp_today_high == 16.0
@@ -443,6 +545,7 @@ def test_today_high_low_falls_back_to_forecasts_entry_rural_shape():
 
 
 def test_today_high_low_none_when_both_absent():
+    """Today's high/low are None when observations and day-level data are both absent."""
     result = normalize_public_data(_current_payload(), {})
     assert result.temp_today_high is None
     assert result.temp_today_low is None
@@ -452,45 +555,60 @@ def test_today_high_low_none_when_both_absent():
 # capability flags
 # ---------------------------------------------------------------------------
 
+
 def test_capability_flags_napier(napier):
+    """Napier fixture reports observations, breakdown, and non-rural capability flags."""
     assert napier.has_observations is True
     assert napier.has_breakdown is True
     assert napier.is_rural is False
 
 
 def test_capability_flags_kumeu(kumeu):
+    """Kumeu fixture reports no observations, no breakdown, and rural capability flags."""
     assert kumeu.has_observations is False
     assert kumeu.has_breakdown is False
     assert kumeu.is_rural is True
 
 
 def test_has_observations_false_when_module_value_is_none():
-    current = {"layout": {"primary": {"slots": {"left-major": {"modules": [{"observations": None}]}}}}}
+    """has_observations is False when the observations module value is None."""
+    current = {
+        "layout": {
+            "primary": {"slots": {"left-major": {"modules": [{"observations": None}]}}}
+        }
+    }
     result = normalize_public_data(current, {})
     assert result.has_observations is False
 
 
 def test_has_observations_false_when_empty_dict():
+    """has_observations is False when observations is an empty dict."""
     result = normalize_public_data(_current_payload(obs={}), {})
     assert result.has_observations is False
 
 
 def test_has_observations_true_when_non_empty_dict():
-    result = normalize_public_data(_current_payload(obs={"temperature": [{"current": 18}]}), {})
+    """has_observations is True when observations is a non-empty dict."""
+    result = normalize_public_data(
+        _current_payload(obs={"temperature": [{"current": 18}]}), {}
+    )
     assert result.has_observations is True
 
 
 def test_is_rural_true():
+    """is_rural is True when the day's isRural flag is the string 'true'."""
     result = normalize_public_data(_current_payload(days=[{"isRural": "true"}]), {})
     assert result.is_rural is True
 
 
 def test_is_rural_false_explicit():
+    """is_rural is False when the day's isRural flag is the string 'false'."""
     result = normalize_public_data(_current_payload(days=[{"isRural": "false"}]), {})
     assert result.is_rural is False
 
 
 def test_is_rural_false_when_absent():
+    """is_rural defaults to False when isRural is absent."""
     result = normalize_public_data(_current_payload(days=[{}]), {})
     assert result.is_rural is False
 
@@ -499,7 +617,9 @@ def test_is_rural_false_when_absent():
 # kumeu (rural) end-to-end contract
 # ---------------------------------------------------------------------------
 
+
 def test_kumeu_observation_fields_are_none(kumeu):
+    """Kumeu (rural) observation fields normalize to None."""
     assert kumeu.temperature is None
     assert kumeu.wind_speed is None
     assert kumeu.wind_gust is None
@@ -509,17 +629,20 @@ def test_kumeu_observation_fields_are_none(kumeu):
 
 
 def test_kumeu_today_high_low_are_floats(kumeu):
+    """Kumeu's today high/low temps are floats."""
     assert isinstance(kumeu.temp_today_high, float)
     assert isinstance(kumeu.temp_today_low, float)
 
 
 def test_kumeu_condition_and_forecast_text(kumeu):
+    """Kumeu's condition and forecast_text are non-empty strings."""
     assert isinstance(kumeu.condition, str)
     assert isinstance(kumeu.forecast_text, str)
     assert len(kumeu.forecast_text) > 0
 
 
 def test_kumeu_tomorrow_fields_present(kumeu):
+    """Kumeu's tomorrow fields are all populated."""
     assert kumeu.tomorrow_condition is not None
     assert kumeu.tomorrow_temp_high is not None
     assert kumeu.tomorrow_temp_low is not None
@@ -527,10 +650,12 @@ def test_kumeu_tomorrow_fields_present(kumeu):
 
 
 def test_kumeu_daily_entries_count(kumeu):
+    """Kumeu's daily_entries count is within the expected 1-14 range."""
     assert 1 <= len(kumeu.daily_entries) <= 14
 
 
 def test_kumeu_daily_entries_complete(kumeu):
+    """Every Kumeu daily entry has condition, temps, description, and rain probability."""
     for i, d in enumerate(kumeu.daily_entries):
         assert d.condition is not None, f"day {i} missing condition"
         assert d.temp_high is not None, f"day {i} missing temp_high"
@@ -540,11 +665,13 @@ def test_kumeu_daily_entries_complete(kumeu):
 
 
 def test_kumeu_hourly_entries_non_empty(kumeu):
+    """Kumeu's hourly_entries is non-empty."""
     assert len(kumeu.hourly_entries) > 0
 
 
 @pytest.mark.parametrize("location", ["napier", "kumeu"])
 def test_rain_probability_exceedance_monotonic(location, napier, kumeu):
+    """Rain probability exceedance is monotonic: the 1mm chance is never below the 10mm chance."""
     data = napier if location == "napier" else kumeu
     for d in data.daily_entries:
         if d.rain_prob_1mm is not None and d.rain_prob_10mm is not None:
@@ -554,6 +681,7 @@ def test_rain_probability_exceedance_monotonic(location, napier, kumeu):
 
 
 def test_napier_daily_entries_have_temp_high_and_description(napier):
+    """Every Napier daily entry has temp_high and description."""
     for i, d in enumerate(napier.daily_entries):
         assert d.temp_high is not None, f"day {i} missing temp_high"
         assert d.description is not None, f"day {i} missing description"

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -13,6 +13,7 @@ from custom_components.metservice_weather.coordinator_types import (
     _get,
     _safe_float,
     _safe_int,
+    _scan_forecasts,
     normalize_public_data,
 )
 
@@ -23,6 +24,13 @@ FIXTURES = Path(__file__).parent / "fixtures"
 def napier():
     current = json.loads((FIXTURES / "napier_public_current.json").read_text())
     daily = json.loads((FIXTURES / "napier_public_daily.json").read_text())
+    return normalize_public_data(current, daily)
+
+
+@pytest.fixture(scope="module")
+def kumeu():
+    current = json.loads((FIXTURES / "kumeu_public_current.json").read_text())
+    daily = json.loads((FIXTURES / "kumeu_public_daily.json").read_text())
     return normalize_public_data(current, daily)
 
 
@@ -232,3 +240,325 @@ def test_empty_dicts_returns_defaults():
     assert result.daily_entries == []
     assert result.hourly_entries == []
     assert result.weather_warnings == "No warnings"
+
+
+# ---------------------------------------------------------------------------
+# _scan_forecasts — forecast entry scanning
+# ---------------------------------------------------------------------------
+
+def test_scan_forecasts_towns_shape_prefers_forecasts_entry():
+    day = {"forecasts": [{"highTemp": 16}], "highTemp": 15}
+    assert _scan_forecasts(day, "highTemp") == 16
+
+
+def test_scan_forecasts_rural_shape_finds_second_entry():
+    day = {
+        "forecasts": [
+            {"statement": "regional", "title": "Region"},
+            {"highTemp": 17, "statement": None},
+        ],
+        "highTemp": 17,
+    }
+    assert _scan_forecasts(day, "highTemp") == 17
+    assert _scan_forecasts(day, "statement") == "regional"
+
+
+def test_scan_forecasts_day_level_only():
+    day = {"highTemp": 12}
+    assert _scan_forecasts(day, "highTemp") == 12
+
+
+def test_scan_forecasts_none_in_forecasts_falls_through_to_day_level():
+    day = {"forecasts": [{"highTemp": None}], "highTemp": 9}
+    assert _scan_forecasts(day, "highTemp") == 9
+
+
+def test_scan_forecasts_absent_everywhere_returns_none():
+    assert _scan_forecasts({}, "highTemp") is None
+
+
+def test_scan_forecasts_non_dict_day_returns_none():
+    assert _scan_forecasts(None, "highTemp") is None
+    assert _scan_forecasts(42, "highTemp") is None
+
+
+def test_scan_forecasts_non_dict_forecast_entries_skipped():
+    day = {"forecasts": ["junk", {"highTemp": 5}]}
+    assert _scan_forecasts(day, "highTemp") == 5
+
+
+# ---------------------------------------------------------------------------
+# daily entry shape heuristics
+# ---------------------------------------------------------------------------
+
+def _daily_payload(days):
+    return {"layout": {"primary": {"slots": {"main": {"modules": [{"days": days}]}}}}}
+
+
+def test_daily_entry_towns_shape():
+    day = {
+        "date": "2024-06-15",
+        "condition": "fine",
+        "forecasts": [
+            {"highTemp": 22, "lowTemp": 12, "statement": "Sunny day", "rainFall1": 30.0, "rainFall10": 5.0}
+        ],
+        "highTemp": 22,
+        "lowTemp": 12,
+        "statement": "Sunny day",
+    }
+    result = normalize_public_data({}, _daily_payload([day]))
+    entry = result.daily_entries[0]
+    assert entry.temp_high == 22.0 and isinstance(entry.temp_high, float)
+    assert entry.temp_low == 12.0 and isinstance(entry.temp_low, float)
+    assert entry.description == "Sunny day"
+    assert entry.rain_prob_1mm == 30.0
+    assert entry.rain_prob_10mm == 5.0
+
+
+def test_daily_entry_rural_shape():
+    day = {
+        "date": "2024-06-15",
+        "condition": "cloudy",
+        "forecasts": [
+            {"statement": "Regional cloudy", "title": "Region"},
+            {"highTemp": 18, "lowTemp": 9, "rainFall1": 40.0, "rainFall10": 10.0, "statement": None},
+        ],
+        "highTemp": 18,
+        "lowTemp": 9,
+        "statement": "Regional cloudy",
+    }
+    result = normalize_public_data({}, _daily_payload([day]))
+    entry = result.daily_entries[0]
+    assert entry.temp_high == 18.0
+    assert entry.temp_low == 9.0
+    assert entry.description == "Regional cloudy"
+    assert entry.rain_prob_1mm == 40.0
+    assert entry.rain_prob_10mm == 10.0
+
+
+def test_daily_entry_day_level_only():
+    day = {"date": "2024-06-15", "condition": "fine", "highTemp": 20, "lowTemp": 10, "statement": "Fine day"}
+    result = normalize_public_data({}, _daily_payload([day]))
+    entry = result.daily_entries[0]
+    assert entry.temp_high == 20.0
+    assert entry.temp_low == 10.0
+    assert entry.description == "Fine day"
+
+
+def test_daily_entry_empty_day():
+    result = normalize_public_data({}, _daily_payload([{}]))
+    entry = result.daily_entries[0]
+    assert entry.datetime is None
+    assert entry.condition is None
+    assert entry.temp_high is None
+    assert entry.temp_low is None
+    assert entry.description is None
+    assert entry.rain_prob_1mm is None
+    assert entry.rain_prob_10mm is None
+
+
+def test_daily_entry_rain_fields_absent_is_none_not_zero():
+    day = {"highTemp": 15, "lowTemp": 8, "statement": "no rain data"}
+    result = normalize_public_data({}, _daily_payload([day]))
+    entry = result.daily_entries[0]
+    assert entry.rain_prob_1mm is None
+    assert entry.rain_prob_10mm is None
+
+
+def test_daily_entry_string_temps_coerced_to_float():
+    day = {"forecasts": [{"highTemp": "16"}]}
+    result = normalize_public_data({}, _daily_payload([day]))
+    entry = result.daily_entries[0]
+    assert entry.temp_high == 16.0
+    assert isinstance(entry.temp_high, float)
+
+
+# ---------------------------------------------------------------------------
+# tomorrow derivation
+# ---------------------------------------------------------------------------
+
+def test_tomorrow_derived_from_day_index_1():
+    days = [
+        {"condition": "fine", "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}]},
+        {"condition": "cloudy", "forecasts": [{"highTemp": 17, "lowTemp": 10, "statement": "Tomorrow cloudy"}]},
+    ]
+    result = normalize_public_data({}, _daily_payload(days))
+    assert result.tomorrow_condition == "cloudy"
+    assert result.tomorrow_temp_high == 17.0 and isinstance(result.tomorrow_temp_high, float)
+    assert result.tomorrow_temp_low == 10.0 and isinstance(result.tomorrow_temp_low, float)
+    assert result.tomorrow_description == "Tomorrow cloudy"
+
+
+def test_tomorrow_none_with_only_one_day():
+    days = [{"condition": "fine", "forecasts": [{"highTemp": 20, "lowTemp": 12, "statement": "Today fine"}]}]
+    result = normalize_public_data({}, _daily_payload(days))
+    assert result.tomorrow_condition is None
+    assert result.tomorrow_temp_high is None
+    assert result.tomorrow_temp_low is None
+    assert result.tomorrow_description is None
+
+
+def test_tomorrow_none_with_empty_daily_dict():
+    result = normalize_public_data({}, {})
+    assert result.tomorrow_condition is None
+    assert result.tomorrow_temp_high is None
+    assert result.tomorrow_temp_low is None
+    assert result.tomorrow_description is None
+
+
+# ---------------------------------------------------------------------------
+# today's high/low fallback
+# ---------------------------------------------------------------------------
+
+def _current_payload(obs=None, days=None):
+    left = [{"observations": obs}] if obs is not None else []
+    main = [{"days": days}] if days is not None else []
+    return {"layout": {"primary": {"slots": {
+        "left-major": {"modules": left},
+        "main": {"modules": main},
+    }}}}
+
+
+def test_today_high_low_prefers_observations():
+    obs = {"temperature": [{"high": 25.0, "low": 15.0, "current": 20.0}]}
+    days = [{"highTemp": 30, "lowTemp": 10}]
+    result = normalize_public_data(_current_payload(obs=obs, days=days), {})
+    assert result.temp_today_high == 25.0
+    assert result.temp_today_low == 15.0
+
+
+def test_today_high_low_falls_back_to_day_level_when_no_observations():
+    """The rural fix: no weather station, so fall back to day 0's forecast temps."""
+    days = [{"highTemp": 18, "lowTemp": 8}]
+    result = normalize_public_data(_current_payload(days=days), {})
+    assert result.temp_today_high == 18.0
+    assert result.temp_today_low == 8.0
+
+
+def test_today_high_low_falls_back_to_forecasts_entry_rural_shape():
+    days = [{"forecasts": [{"statement": "regional"}, {"highTemp": 16, "lowTemp": 6}]}]
+    result = normalize_public_data(_current_payload(days=days), {})
+    assert result.temp_today_high == 16.0
+    assert result.temp_today_low == 6.0
+
+
+def test_today_high_low_none_when_both_absent():
+    result = normalize_public_data(_current_payload(), {})
+    assert result.temp_today_high is None
+    assert result.temp_today_low is None
+
+
+# ---------------------------------------------------------------------------
+# capability flags
+# ---------------------------------------------------------------------------
+
+def test_capability_flags_napier(napier):
+    assert napier.has_observations is True
+    assert napier.has_breakdown is True
+    assert napier.is_rural is False
+
+
+def test_capability_flags_kumeu(kumeu):
+    assert kumeu.has_observations is False
+    assert kumeu.has_breakdown is False
+    assert kumeu.is_rural is True
+
+
+def test_has_observations_false_when_module_value_is_none():
+    current = {"layout": {"primary": {"slots": {"left-major": {"modules": [{"observations": None}]}}}}}
+    result = normalize_public_data(current, {})
+    assert result.has_observations is False
+
+
+def test_has_observations_false_when_empty_dict():
+    result = normalize_public_data(_current_payload(obs={}), {})
+    assert result.has_observations is False
+
+
+def test_has_observations_true_when_non_empty_dict():
+    result = normalize_public_data(_current_payload(obs={"temperature": [{"current": 18}]}), {})
+    assert result.has_observations is True
+
+
+def test_is_rural_true():
+    result = normalize_public_data(_current_payload(days=[{"isRural": "true"}]), {})
+    assert result.is_rural is True
+
+
+def test_is_rural_false_explicit():
+    result = normalize_public_data(_current_payload(days=[{"isRural": "false"}]), {})
+    assert result.is_rural is False
+
+
+def test_is_rural_false_when_absent():
+    result = normalize_public_data(_current_payload(days=[{}]), {})
+    assert result.is_rural is False
+
+
+# ---------------------------------------------------------------------------
+# kumeu (rural) end-to-end contract
+# ---------------------------------------------------------------------------
+
+def test_kumeu_observation_fields_are_none(kumeu):
+    assert kumeu.temperature is None
+    assert kumeu.wind_speed is None
+    assert kumeu.wind_gust is None
+    assert kumeu.humidity is None
+    assert kumeu.pressure is None
+    assert kumeu.rainfall is None
+
+
+def test_kumeu_today_high_low_are_floats(kumeu):
+    assert isinstance(kumeu.temp_today_high, float)
+    assert isinstance(kumeu.temp_today_low, float)
+
+
+def test_kumeu_condition_and_forecast_text(kumeu):
+    assert isinstance(kumeu.condition, str)
+    assert isinstance(kumeu.forecast_text, str)
+    assert len(kumeu.forecast_text) > 0
+
+
+def test_kumeu_tomorrow_fields_present(kumeu):
+    assert kumeu.tomorrow_condition is not None
+    assert kumeu.tomorrow_temp_high is not None
+    assert kumeu.tomorrow_temp_low is not None
+    assert kumeu.tomorrow_description is not None
+
+
+def test_kumeu_daily_entries_count(kumeu):
+    assert 1 <= len(kumeu.daily_entries) <= 14
+
+
+def test_kumeu_daily_entries_complete(kumeu):
+    for i, d in enumerate(kumeu.daily_entries):
+        assert d.condition is not None, f"day {i} missing condition"
+        assert d.temp_high is not None, f"day {i} missing temp_high"
+        assert d.temp_low is not None, f"day {i} missing temp_low"
+        assert d.description is not None, f"day {i} missing description"
+        assert d.rain_prob_1mm is not None, f"day {i} missing rain_prob_1mm"
+
+
+def test_kumeu_hourly_entries_non_empty(kumeu):
+    assert len(kumeu.hourly_entries) > 0
+
+
+@pytest.mark.parametrize("location", ["napier", "kumeu"])
+def test_rain_probability_exceedance_monotonic(location, napier, kumeu):
+    data = napier if location == "napier" else kumeu
+    for d in data.daily_entries:
+        if d.rain_prob_1mm is not None and d.rain_prob_10mm is not None:
+            assert d.rain_prob_1mm >= d.rain_prob_10mm
+            assert 0 <= d.rain_prob_1mm <= 100
+            assert 0 <= d.rain_prob_10mm <= 100
+
+
+def test_napier_daily_entries_have_temp_high_and_description(napier):
+    for i, d in enumerate(napier.daily_entries):
+        assert d.temp_high is not None, f"day {i} missing temp_high"
+        assert d.description is not None, f"day {i} missing description"
+
+
+def test_napier_daily_entries_have_some_rain_probability(napier):
+    """Towns pages publish rain probabilities from day ~2 onward, not day 0."""
+    assert any(d.rain_prob_1mm is not None for d in napier.daily_entries)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for WeatherSensor entity and weather_current_conditions_sensors helpers."""
+
 from __future__ import annotations
 
 import datetime
@@ -23,6 +24,7 @@ from custom_components.metservice_weather.coordinator_types import MetServicePub
 # ---------------------------------------------------------------------------
 # Helper: minimal coordinator with pre-loaded data
 # ---------------------------------------------------------------------------
+
 
 def _make_coordinator(hass) -> WeatherUpdateCoordinator:
     config = WeatherUpdateCoordinatorConfig(
@@ -63,54 +65,71 @@ def _make_sensor(coordinator, key="temperature", value=18.5) -> WeatherSensor:
 # Test: helper functions in weather_current_conditions_sensors.py
 # ---------------------------------------------------------------------------
 
+
 def test_safe_float_none():
+    """_safe_float returns None for a None input."""
     assert _safe_float(None) is None
 
 
 def test_safe_float_valid():
+    """_safe_float converts a numeric string or float to float."""
     assert _safe_float("18.5") == 18.5
     assert _safe_float(18.5) == 18.5
 
 
 def test_safe_float_invalid():
+    """_safe_float returns None for invalid or empty strings."""
     assert _safe_float("n/a") is None
     assert _safe_float("") is None
 
 
 def test_safe_int_none():
+    """_safe_int returns None for a None input."""
     assert _safe_int(None) is None
 
 
 def test_safe_int_valid():
+    """_safe_int converts a numeric string or int to int."""
     assert _safe_int("5") == 5
     assert _safe_int(5) == 5
 
 
 def test_safe_int_invalid():
+    """_safe_int returns None for an invalid string."""
     assert _safe_int("n/a") is None
 
 
 def test_next_tide_time_not_list():
+    """_next_tide_time returns None when tides is not a list."""
     assert _next_tide_time(None, "HIGH") is None
     assert _next_tide_time({}, "HIGH") is None
 
 
 def test_next_tide_time_future():
-    future = (datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)).isoformat()
+    """_next_tide_time returns a value for a future tide of the matching type."""
+    future = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)
+    ).isoformat()
     tides = [{"type": "HIGH", "time": future}]
     result = _next_tide_time(tides, "HIGH")
     assert result is not None
 
 
 def test_next_tide_time_past_returns_none():
-    past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)).isoformat()
+    """_next_tide_time returns None when the matching tide is in the past."""
+    past = (
+        datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=2)
+    ).isoformat()
     tides = [{"type": "HIGH", "time": past}]
     result = _next_tide_time(tides, "HIGH")
     assert result is None
 
 
 def test_next_tide_time_wrong_type_returns_none():
-    future = (datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)).isoformat()
+    """_next_tide_time returns None when no tide matches the requested type."""
+    future = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)
+    ).isoformat()
     tides = [{"type": "LOW", "time": future}]
     result = _next_tide_time(tides, "HIGH")
     assert result is None
@@ -120,7 +139,9 @@ def test_next_tide_time_wrong_type_returns_none():
 # Test: sensor descriptions are non-empty lists
 # ---------------------------------------------------------------------------
 
+
 def test_public_sensor_descriptions_non_empty():
+    """current_condition_sensor_descriptions_public is a non-empty list."""
     assert len(current_condition_sensor_descriptions_public) > 0
 
 
@@ -128,13 +149,16 @@ def test_public_sensor_descriptions_non_empty():
 # Test: WeatherSensor properties
 # ---------------------------------------------------------------------------
 
+
 async def test_sensor_name(hass):
+    """WeatherSensor.name reflects the entity description's name."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value=20.0)
     assert sensor.name == "Test Sensor"
 
 
 async def test_sensor_native_value_with_data(hass):
+    """WeatherSensor.native_value returns the value_fn result when data is present."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value=18.5)
     # _sensor_data was set to 18.5 in the constructor; value_fn just returns data
@@ -142,6 +166,7 @@ async def test_sensor_native_value_with_data(hass):
 
 
 async def test_sensor_native_value_none_data(hass):
+    """WeatherSensor.native_value is None when the underlying value is None."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value=None)
     assert sensor.native_value is None
@@ -160,6 +185,7 @@ async def test_sensor_native_value_fn_error_returns_none(hass):
 
 
 async def test_sensor_extra_state_attributes_with_data(hass):
+    """WeatherSensor.extra_state_attributes returns the attr_fn result when data is present."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value="some text")
     attrs = sensor.extra_state_attributes
@@ -167,12 +193,14 @@ async def test_sensor_extra_state_attributes_with_data(hass):
 
 
 async def test_sensor_extra_state_attributes_none_data(hass):
+    """WeatherSensor.extra_state_attributes is empty when the underlying value is None."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value=None)
     assert sensor.extra_state_attributes == {}
 
 
 async def test_sensor_extra_state_attributes_fn_error_returns_empty(hass):
+    """If attr_fn raises, extra_state_attributes returns an empty dict without crashing."""
     coord = _make_coordinator(hass)
     desc = WeatherSensorEntityDescription(
         key="temperature",
@@ -185,6 +213,7 @@ async def test_sensor_extra_state_attributes_fn_error_returns_empty(hass):
 
 
 async def test_sensor_handle_coordinator_update_public(hass):
+    """_handle_coordinator_update refreshes _sensor_data from the coordinator."""
     coord = _make_coordinator(hass)
     sensor = _make_sensor(coord, value=10.0)
     updated_data = MetServicePublicData(temperature=22.5)
@@ -195,6 +224,7 @@ async def test_sensor_handle_coordinator_update_public(hass):
 
 
 async def test_sensor_available_when_coordinator_failed(hass):
+    """WeatherSensor.available is False when the coordinator's last update failed."""
     coord = _make_coordinator(hass)
     coord.last_update_success = False
     sensor = _make_sensor(coord, value=5.0)
@@ -202,6 +232,7 @@ async def test_sensor_available_when_coordinator_failed(hass):
 
 
 async def test_sensor_available_when_coordinator_ok(hass):
+    """WeatherSensor.available is True when the coordinator's last update succeeded."""
     coord = _make_coordinator(hass)
     coord.last_update_success = True
     sensor = _make_sensor(coord, value=5.0)
@@ -211,6 +242,7 @@ async def test_sensor_available_when_coordinator_ok(hass):
 # ---------------------------------------------------------------------------
 # Test: async_setup_entry creates expected sensors
 # ---------------------------------------------------------------------------
+
 
 async def test_sensor_setup_entry_public_skips_tide_sensors(hass):
     """When no tide URL, tides_high and tides_low are excluded."""
@@ -252,11 +284,9 @@ async def test_sensor_setup_entry_public_skips_tide_sensors(hass):
 # Test: async_setup_entry sensor gating by capability flags
 # ---------------------------------------------------------------------------
 
+
 async def test_setup_entry_rural_skips_observation_sensors(hass):
-    """A rural-like coordinator (all capability flags False, as _make_coordinator
-    sets by default) must not create observation or breakdown sensors, while
-    ungated sensors are still created.
-    """
+    """A rural-like coordinator (all capability flags False) skips observation and breakdown sensors while still creating ungated sensors."""
     from custom_components.metservice_weather.sensor import async_setup_entry
     from pytest_homeassistant_custom_component.common import MockConfigEntry
     from custom_components.metservice_weather.const import (
@@ -281,7 +311,9 @@ async def test_setup_entry_rural_skips_observation_sensors(hass):
             "surf_url": "",
         },
     )
-    coord = _make_coordinator(hass)  # coord.data = MetServicePublicData() — all capability flags False
+    coord = _make_coordinator(
+        hass
+    )  # coord.data = MetServicePublicData() — all capability flags False
     entry.runtime_data = coord
 
     added = []
@@ -322,9 +354,7 @@ async def test_setup_entry_rural_skips_observation_sensors(hass):
 
 
 async def test_setup_entry_towns_creates_observation_sensors(hass):
-    """A towns-cities coordinator with observations + breakdown present creates
-    the sensors that the rural-like default coordinator skips.
-    """
+    """A towns-cities coordinator with observations and breakdown present creates the sensors that the rural-like default coordinator skips."""
     from custom_components.metservice_weather.sensor import async_setup_entry
     from pytest_homeassistant_custom_component.common import MockConfigEntry
     from custom_components.metservice_weather.const import (
@@ -382,9 +412,7 @@ async def test_setup_entry_towns_creates_observation_sensors(hass):
 
 
 async def test_setup_entry_removes_stale_registry_entries(hass):
-    """Registry entries for sensors the location no longer provides are removed;
-    sensors still provided and the weather-domain entity are left untouched.
-    """
+    """Registry entries for sensors the location no longer provides are removed, while still-provided sensors and the weather-domain entity are left untouched."""
     from custom_components.metservice_weather.sensor import async_setup_entry
     from pytest_homeassistant_custom_component.common import MockConfigEntry
     from homeassistant.helpers import entity_registry as er
@@ -431,5 +459,3 @@ async def test_setup_entry_removes_stale_registry_entries(hass):
     assert ent_reg.async_get(stale.entity_id) is None
     assert ent_reg.async_get(keep.entity_id) is not None
     assert ent_reg.async_get(weather_ent.entity_id) is not None
-
-

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -248,3 +248,188 @@ async def test_sensor_setup_entry_public_skips_tide_sensors(hass):
     assert "tides_low" not in keys
 
 
+# ---------------------------------------------------------------------------
+# Test: async_setup_entry sensor gating by capability flags
+# ---------------------------------------------------------------------------
+
+async def test_setup_entry_rural_skips_observation_sensors(hass):
+    """A rural-like coordinator (all capability flags False, as _make_coordinator
+    sets by default) must not create observation or breakdown sensors, while
+    ungated sensors are still created.
+    """
+    from custom_components.metservice_weather.sensor import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.metservice_weather.const import (
+        DOMAIN,
+        FIELD_TEMP,
+        FIELD_WINDSPEED,
+        FIELD_WINDGUST,
+        FIELD_WINDDIR,
+        FIELD_HUMIDITY,
+        FIELD_PRESSURE,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Kumeu",
+            "location": "/rural/regions/auckland/locations/kumeu",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    coord = _make_coordinator(hass)  # coord.data = MetServicePublicData() — all capability flags False
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    keys = {s.entity_description.key for s in added}
+
+    excluded = {
+        FIELD_TEMP,
+        FIELD_WINDSPEED,
+        FIELD_WINDGUST,
+        FIELD_WINDDIR,
+        FIELD_HUMIDITY,
+        FIELD_PRESSURE,
+        "wind_strength",
+        "rainfall",
+        "pressureTendencyTrend",
+        "temperatureFeelsLike",
+        "breakdown_morning",
+        "breakdown_afternoon",
+        "breakdown_evening",
+        "breakdown_overnight",
+    }
+    assert keys.isdisjoint(excluded)
+
+    included = {
+        "temperature_today_high",
+        "temperature_today_low",
+        "tomorrow_temp_high",
+        "weather_warnings",
+        "uvIndex",
+    }
+    assert included.issubset(keys)
+
+
+async def test_setup_entry_towns_creates_observation_sensors(hass):
+    """A towns-cities coordinator with observations + breakdown present creates
+    the sensors that the rural-like default coordinator skips.
+    """
+    from custom_components.metservice_weather.sensor import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.metservice_weather.const import (
+        DOMAIN,
+        FIELD_TEMP,
+        FIELD_WINDSPEED,
+        FIELD_WINDGUST,
+        FIELD_WINDDIR,
+        FIELD_HUMIDITY,
+        FIELD_PRESSURE,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Napier",
+            "location": "/towns-cities/regions/hawkes-bay/locations/napier",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    coord = _make_coordinator(hass)
+    coord.data = MetServicePublicData(has_observations=True, has_breakdown=True)
+    entry.runtime_data = coord
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    keys = {s.entity_description.key for s in added}
+
+    included = {
+        FIELD_TEMP,
+        FIELD_WINDSPEED,
+        FIELD_WINDGUST,
+        FIELD_WINDDIR,
+        FIELD_HUMIDITY,
+        FIELD_PRESSURE,
+        "wind_strength",
+        "rainfall",
+        "pressureTendencyTrend",
+        "temperatureFeelsLike",
+        "breakdown_morning",
+        "breakdown_afternoon",
+        "breakdown_evening",
+        "breakdown_overnight",
+    }
+    assert included.issubset(keys)
+
+
+async def test_setup_entry_removes_stale_registry_entries(hass):
+    """Registry entries for sensors the location no longer provides are removed;
+    sensors still provided and the weather-domain entity are left untouched.
+    """
+    from custom_components.metservice_weather.sensor import async_setup_entry
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+    from custom_components.metservice_weather.const import DOMAIN, FIELD_TEMP
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Napier",
+            "location": "/towns-cities/regions/hawkes-bay/locations/napier",
+            "api": "public",
+            "marine_region": "",
+            "tide_url": "",
+            "boating_url": "",
+            "surf_url": "",
+        },
+    )
+    entry.add_to_hass(hass)
+    coord = _make_coordinator(hass)  # rural-like: obs sensors will NOT be created
+    entry.runtime_data = coord
+    loc = coord.location
+
+    ent_reg = er.async_get(hass)
+    # FIELD_TEMP is gated on has_observations, which the default (rural-like)
+    # coordinator data does not have — so it will be treated as stale.
+    stale = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{loc}_{FIELD_TEMP}".lower(), config_entry=entry
+    )
+    # weather_warnings is ungated, so it is always (re)created.
+    keep = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{loc}_weather_warnings".lower(), config_entry=entry
+    )
+    weather_ent = ent_reg.async_get_or_create(
+        "weather", DOMAIN, f"{loc}_weather".lower(), config_entry=entry
+    )
+
+    added = []
+
+    def add_entities(entities, *args, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    assert ent_reg.async_get(stale.entity_id) is None
+    assert ent_reg.async_get(keep.entity_id) is not None
+    assert ent_reg.async_get(weather_ent.entity_id) is not None
+
+

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -125,6 +125,25 @@ async def test_public_entity_humidity(hass):
     assert entity.humidity == 75
 
 
+async def test_public_entity_properties_safe_when_data_is_none(hass):
+    """Every property returns None/[] when the coordinator has no data yet.
+
+    Regression test: with a mocked first refresh the coordinator data is None
+    during entity addition, which previously raised AttributeError in CI.
+    """
+    coord = _make_coordinator(hass)
+    coord.data = None
+    entity = MetServiceForecastPublic(coord)
+    assert entity.native_temperature is None
+    assert entity.native_pressure is None
+    assert entity.humidity is None
+    assert entity.native_wind_speed is None
+    assert entity.wind_bearing is None
+    assert entity.condition is None
+    assert entity.forecast_hourly == []
+    assert entity.forecast_daily == []
+
+
 async def test_public_entity_humidity_none(hass):
     """Humidity is None when coordinator.data.humidity is unset."""
     coord = _make_coordinator(hass)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -282,7 +282,7 @@ async def test_public_forecast_daily_with_data(hass):
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
         daily_entries=[
-            DailyEntry(condition="fine", temp_high=22.0, temp_low=12.0, datetime="2024-06-15", description="Sunny day", rainfall_low=0.0, rainfall_high=1.0),
+            DailyEntry(condition="fine", temp_high=22.0, temp_low=12.0, datetime="2024-06-15", description="Sunny day", rain_prob_1mm=0.0, rain_prob_10mm=1.0),
             DailyEntry(condition="cloudy", temp_high=18.0, temp_low=10.0, datetime="2024-06-16"),
         ]
     )
@@ -294,17 +294,58 @@ async def test_public_forecast_daily_with_data(hass):
     assert result[0]["condition"] == CONDITION_MAP["fine"]
 
 
-async def test_public_forecast_daily_precipitation_fields(hass):
-    """rainfall_low is mapped to the standard native_precipitation key."""
+async def test_public_forecast_daily_precipitation_probability(hass):
+    """MetService publishes rainfall exceedance probabilities (% chance of
+    >=1mm / >=10mm), not amounts, so rain_prob_1mm maps to the standard
+    precipitation_probability key — never to native_precipitation.
+    """
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        daily_entries=[DailyEntry(condition="rain", temp_high=15.0, temp_low=8.0, datetime="2024-06-15", rainfall_low=2.0, rainfall_high=8.0)]
+        daily_entries=[DailyEntry(condition="rain", temp_high=15.0, temp_low=8.0, datetime="2024-06-15", rain_prob_1mm=50.0, rain_prob_10mm=5.0)]
     )
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_daily
-    assert result[0]["native_precipitation"] == 2.0
+    assert result[0]["precipitation_probability"] == 50
+    assert "native_precipitation" not in result[0]
     assert "precipitation_low_mm" not in result[0]
     assert "precipitation_high_mm" not in result[0]
+
+
+async def test_public_forecast_daily_precipitation_probability_absent_when_none(hass):
+    coord = _make_coordinator(hass)
+    coord.data = MetServicePublicData(
+        daily_entries=[DailyEntry(condition="fine", temp_high=20.0, temp_low=10.0, datetime="2024-06-15", rain_prob_1mm=None)]
+    )
+    entity = MetServiceForecastPublic(coord)
+    result = entity.forecast_daily
+    assert "precipitation_probability" not in result[0]
+
+
+async def test_public_forecast_daily_precipitation_probability_rounds_to_int(hass):
+    coord = _make_coordinator(hass)
+    coord.data = MetServicePublicData(
+        daily_entries=[DailyEntry(condition="rain", temp_high=15.0, temp_low=8.0, datetime="2024-06-15", rain_prob_1mm=32.6)]
+    )
+    entity = MetServiceForecastPublic(coord)
+    result = entity.forecast_daily
+    assert result[0]["precipitation_probability"] == 33
+    assert isinstance(result[0]["precipitation_probability"], int)
+
+
+async def test_public_forecast_daily_rural_style_entries_have_temps(hass):
+    """Rural daily entries (temps + description via _scan_forecasts fallback,
+    no observations at all) still produce a full forecast entry.
+    """
+    coord = _make_coordinator(hass)
+    coord.data = MetServicePublicData(
+        daily_entries=[
+            DailyEntry(condition="cloudy", temp_high=17.0, temp_low=5.0, datetime="2024-06-15", description="Regional cloudy")
+        ]
+    )
+    entity = MetServiceForecastPublic(coord)
+    result = entity.forecast_daily
+    assert result[0]["native_temperature"] == 17.0
+    assert result[0]["native_templow"] == 5.0
 
 
 async def test_public_async_forecast_hourly(hass):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,4 +1,5 @@
 """Tests for MetService weather entities (public and mobile)."""
+
 from __future__ import annotations
 
 from unittest.mock import patch, AsyncMock
@@ -26,7 +27,10 @@ from custom_components.metservice_weather.weather import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_coordinator(hass, tide_url="", boating_url="", surf_url="") -> WeatherUpdateCoordinator:
+
+def _make_coordinator(
+    hass, tide_url="", boating_url="", surf_url=""
+) -> WeatherUpdateCoordinator:
     config = WeatherUpdateCoordinatorConfig(
         api_url="https://www.metservice.com/publicData/webdata",
         warnings_url="https://www.metservice.com/publicData/webdata/warnings-service",
@@ -47,7 +51,9 @@ def _make_coordinator(hass, tide_url="", boating_url="", surf_url="") -> Weather
 # Test: async_setup_entry
 # ---------------------------------------------------------------------------
 
+
 async def test_weather_setup_entry_public(hass):
+    """async_setup_entry creates a single MetServiceForecastPublic entity."""
     from custom_components.metservice_weather.weather import async_setup_entry
     from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -80,19 +86,23 @@ async def test_weather_setup_entry_public(hass):
 # Test: MetServiceForecastPublic properties
 # ---------------------------------------------------------------------------
 
+
 async def test_public_entity_name(hass):
+    """MetServiceForecastPublic.name is 'Forecast'."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.name == "Forecast"
 
 
 async def test_public_entity_unique_id(hass):
+    """MetServiceForecastPublic.unique_id includes the location slug."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert "napier" in entity.unique_id.lower()
 
 
 async def test_public_entity_temperature(hass):
+    """native_temperature reflects coordinator.data.temperature."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(temperature=18.5)
     entity = MetServiceForecastPublic(coord)
@@ -100,6 +110,7 @@ async def test_public_entity_temperature(hass):
 
 
 async def test_public_entity_pressure(hass):
+    """native_pressure reflects coordinator.data.pressure."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(pressure=1013.0)
     entity = MetServiceForecastPublic(coord)
@@ -107,6 +118,7 @@ async def test_public_entity_pressure(hass):
 
 
 async def test_public_entity_humidity(hass):
+    """Humidity reflects coordinator.data.humidity."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(humidity=75)
     entity = MetServiceForecastPublic(coord)
@@ -114,12 +126,14 @@ async def test_public_entity_humidity(hass):
 
 
 async def test_public_entity_humidity_none(hass):
+    """Humidity is None when coordinator.data.humidity is unset."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.humidity is None
 
 
 async def test_public_entity_wind_speed(hass):
+    """native_wind_speed reflects coordinator.data.wind_speed."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(wind_speed=25.0)
     entity = MetServiceForecastPublic(coord)
@@ -127,6 +141,7 @@ async def test_public_entity_wind_speed(hass):
 
 
 async def test_public_entity_wind_bearing(hass):
+    """wind_bearing reflects coordinator.data.wind_direction."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(wind_direction="NW")
     entity = MetServiceForecastPublic(coord)
@@ -134,11 +149,15 @@ async def test_public_entity_wind_bearing(hass):
 
 
 async def test_public_entity_condition_mapped(hass):
+    """Condition maps the raw MetService condition through CONDITION_MAP while the sun is up."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(condition="rain")
     entity = MetServiceForecastPublic(coord)
     entity.hass = hass
-    with patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=True):
+    with patch(
+        "custom_components.metservice_weather.weather.sun_helper.is_up",
+        return_value=True,
+    ):
         cond = entity.condition
     assert cond == CONDITION_MAP["rain"]
 
@@ -149,7 +168,10 @@ async def test_public_entity_condition_clear_night(hass):
     coord.data = MetServicePublicData(condition="fine")
     entity = MetServiceForecastPublic(coord)
     entity.hass = hass
-    with patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=False):
+    with patch(
+        "custom_components.metservice_weather.weather.sun_helper.is_up",
+        return_value=False,
+    ):
         cond = entity.condition
     assert cond == "clear-night"
 
@@ -160,30 +182,37 @@ async def test_public_entity_condition_unknown_passthrough(hass):
     coord.data = MetServicePublicData(condition="unknown-condition")
     entity = MetServiceForecastPublic(coord)
     entity.hass = hass
-    with patch("custom_components.metservice_weather.weather.sun_helper.is_up", return_value=True):
+    with patch(
+        "custom_components.metservice_weather.weather.sun_helper.is_up",
+        return_value=True,
+    ):
         cond = entity.condition
     assert cond == "unknown-condition"
 
 
 async def test_public_entity_temperature_units(hass):
+    """native_temperature_unit is set."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.native_temperature_unit is not None
 
 
 async def test_public_entity_pressure_units(hass):
+    """native_pressure_unit is set."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.native_pressure_unit is not None
 
 
 async def test_public_entity_wind_speed_units(hass):
+    """native_wind_speed_unit is set."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.native_wind_speed_unit is not None
 
 
 async def test_public_entity_precipitation_units(hass):
+    """native_precipitation_unit is set."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.native_precipitation_unit is not None
@@ -193,6 +222,7 @@ async def test_public_entity_precipitation_units(hass):
 # Test: MetServiceForecastPublic forecast_hourly
 # ---------------------------------------------------------------------------
 
+
 def _hourly_data(**kwargs) -> MetServicePublicData:
     """Build a MetServicePublicData with one HourlyEntry for icon tests."""
     entry = HourlyEntry(**kwargs)
@@ -200,6 +230,7 @@ def _hourly_data(**kwargs) -> MetServicePublicData:
 
 
 async def test_public_forecast_hourly_empty_when_no_data(hass):
+    """forecast_hourly is an empty list when there are no hourly entries."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_hourly
@@ -207,11 +238,24 @@ async def test_public_forecast_hourly_empty_when_no_data(hass):
 
 
 async def test_public_forecast_hourly_with_data(hass):
+    """forecast_hourly converts HourlyEntry data into forecast dicts."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
         hourly_entries=[
-            HourlyEntry(datetime="2024-06-15T10:00:00+12:00", temperature=18.0, rainfall=0.0, wind_speed=15.0, wind_direction="NW"),
-            HourlyEntry(datetime="2024-06-15T22:00:00+12:00", temperature=12.0, rainfall=0.0, wind_speed=10.0, wind_direction="SW"),
+            HourlyEntry(
+                datetime="2024-06-15T10:00:00+12:00",
+                temperature=18.0,
+                rainfall=0.0,
+                wind_speed=15.0,
+                wind_direction="NW",
+            ),
+            HourlyEntry(
+                datetime="2024-06-15T22:00:00+12:00",
+                temperature=12.0,
+                rainfall=0.0,
+                wind_speed=10.0,
+                wind_direction="SW",
+            ),
         ],
         hourly_obs=2,
         hourly_skip=0,
@@ -223,29 +267,57 @@ async def test_public_forecast_hourly_with_data(hass):
 
 
 async def test_public_forecast_hourly_heavy_rain_icon(hass):
+    """forecast_hourly maps heavy rainfall to the 'pouring' condition icon."""
     coord = _make_coordinator(hass)
-    coord.data = _hourly_data(datetime="2024-06-15T10:00:00+12:00", temperature=10.0, rainfall=10.0, wind_speed=5.0, wind_direction="N")
+    coord.data = _hourly_data(
+        datetime="2024-06-15T10:00:00+12:00",
+        temperature=10.0,
+        rainfall=10.0,
+        wind_speed=5.0,
+        wind_direction="N",
+    )
     entity = MetServiceForecastPublic(coord)
     assert entity.forecast_hourly[0]["condition"] == "pouring"
 
 
 async def test_public_forecast_hourly_light_rain_icon(hass):
+    """forecast_hourly maps light rainfall to the 'rainy' condition icon."""
     coord = _make_coordinator(hass)
-    coord.data = _hourly_data(datetime="2024-06-15T10:00:00+12:00", temperature=12.0, rainfall=2.0, wind_speed=5.0, wind_direction="N")
+    coord.data = _hourly_data(
+        datetime="2024-06-15T10:00:00+12:00",
+        temperature=12.0,
+        rainfall=2.0,
+        wind_speed=5.0,
+        wind_direction="N",
+    )
     entity = MetServiceForecastPublic(coord)
     assert entity.forecast_hourly[0]["condition"] == "rainy"
 
 
 async def test_public_forecast_hourly_windy_icon(hass):
+    """forecast_hourly maps high wind speed to the 'windy' condition icon."""
     coord = _make_coordinator(hass)
-    coord.data = _hourly_data(datetime="2024-06-15T14:00:00+12:00", temperature=15.0, rainfall=0.0, wind_speed=50.0, wind_direction="SW")
+    coord.data = _hourly_data(
+        datetime="2024-06-15T14:00:00+12:00",
+        temperature=15.0,
+        rainfall=0.0,
+        wind_speed=50.0,
+        wind_direction="SW",
+    )
     entity = MetServiceForecastPublic(coord)
     assert entity.forecast_hourly[0]["condition"] == "windy"
 
 
 async def test_public_forecast_hourly_night_icon(hass):
+    """forecast_hourly maps a nighttime hour with no rain or wind to 'clear-night'."""
     coord = _make_coordinator(hass)
-    coord.data = _hourly_data(datetime="2024-06-15T22:00:00+12:00", temperature=8.0, rainfall=0.0, wind_speed=5.0, wind_direction="N")
+    coord.data = _hourly_data(
+        datetime="2024-06-15T22:00:00+12:00",
+        temperature=8.0,
+        rainfall=0.0,
+        wind_speed=5.0,
+        wind_direction="N",
+    )
     entity = MetServiceForecastPublic(coord)
     assert entity.forecast_hourly[0]["condition"] == "clear-night"
 
@@ -255,8 +327,18 @@ async def test_public_forecast_hourly_skip_offsets_start(hass):
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
         hourly_entries=[
-            HourlyEntry(datetime="2024-06-15T08:00:00+12:00", temperature=10.0, rainfall=0.0, wind_speed=5.0),
-            HourlyEntry(datetime="2024-06-15T10:00:00+12:00", temperature=18.0, rainfall=0.0, wind_speed=5.0),
+            HourlyEntry(
+                datetime="2024-06-15T08:00:00+12:00",
+                temperature=10.0,
+                rainfall=0.0,
+                wind_speed=5.0,
+            ),
+            HourlyEntry(
+                datetime="2024-06-15T10:00:00+12:00",
+                temperature=18.0,
+                rainfall=0.0,
+                wind_speed=5.0,
+            ),
         ],
         hourly_obs=1,
         hourly_skip=1,
@@ -271,7 +353,9 @@ async def test_public_forecast_hourly_skip_offsets_start(hass):
 # Test: MetServiceForecastPublic forecast_daily
 # ---------------------------------------------------------------------------
 
+
 async def test_public_forecast_daily_empty_when_no_days(hass):
+    """forecast_daily is an empty list when there are no daily entries."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_daily
@@ -279,11 +363,22 @@ async def test_public_forecast_daily_empty_when_no_days(hass):
 
 
 async def test_public_forecast_daily_with_data(hass):
+    """forecast_daily converts DailyEntry data into forecast dicts with mapped condition."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
         daily_entries=[
-            DailyEntry(condition="fine", temp_high=22.0, temp_low=12.0, datetime="2024-06-15", description="Sunny day", rain_prob_1mm=0.0, rain_prob_10mm=1.0),
-            DailyEntry(condition="cloudy", temp_high=18.0, temp_low=10.0, datetime="2024-06-16"),
+            DailyEntry(
+                condition="fine",
+                temp_high=22.0,
+                temp_low=12.0,
+                datetime="2024-06-15",
+                description="Sunny day",
+                rain_prob_1mm=0.0,
+                rain_prob_10mm=1.0,
+            ),
+            DailyEntry(
+                condition="cloudy", temp_high=18.0, temp_low=10.0, datetime="2024-06-16"
+            ),
         ]
     )
     entity = MetServiceForecastPublic(coord)
@@ -295,13 +390,19 @@ async def test_public_forecast_daily_with_data(hass):
 
 
 async def test_public_forecast_daily_precipitation_probability(hass):
-    """MetService publishes rainfall exceedance probabilities (% chance of
-    >=1mm / >=10mm), not amounts, so rain_prob_1mm maps to the standard
-    precipitation_probability key — never to native_precipitation.
-    """
+    """MetService publishes rainfall exceedance probabilities, so rain_prob_1mm maps to precipitation_probability, never to native_precipitation."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        daily_entries=[DailyEntry(condition="rain", temp_high=15.0, temp_low=8.0, datetime="2024-06-15", rain_prob_1mm=50.0, rain_prob_10mm=5.0)]
+        daily_entries=[
+            DailyEntry(
+                condition="rain",
+                temp_high=15.0,
+                temp_low=8.0,
+                datetime="2024-06-15",
+                rain_prob_1mm=50.0,
+                rain_prob_10mm=5.0,
+            )
+        ]
     )
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_daily
@@ -312,9 +413,18 @@ async def test_public_forecast_daily_precipitation_probability(hass):
 
 
 async def test_public_forecast_daily_precipitation_probability_absent_when_none(hass):
+    """precipitation_probability is omitted from the forecast dict when rain_prob_1mm is None."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        daily_entries=[DailyEntry(condition="fine", temp_high=20.0, temp_low=10.0, datetime="2024-06-15", rain_prob_1mm=None)]
+        daily_entries=[
+            DailyEntry(
+                condition="fine",
+                temp_high=20.0,
+                temp_low=10.0,
+                datetime="2024-06-15",
+                rain_prob_1mm=None,
+            )
+        ]
     )
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_daily
@@ -322,9 +432,18 @@ async def test_public_forecast_daily_precipitation_probability_absent_when_none(
 
 
 async def test_public_forecast_daily_precipitation_probability_rounds_to_int(hass):
+    """precipitation_probability is rounded to the nearest int."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        daily_entries=[DailyEntry(condition="rain", temp_high=15.0, temp_low=8.0, datetime="2024-06-15", rain_prob_1mm=32.6)]
+        daily_entries=[
+            DailyEntry(
+                condition="rain",
+                temp_high=15.0,
+                temp_low=8.0,
+                datetime="2024-06-15",
+                rain_prob_1mm=32.6,
+            )
+        ]
     )
     entity = MetServiceForecastPublic(coord)
     result = entity.forecast_daily
@@ -333,13 +452,17 @@ async def test_public_forecast_daily_precipitation_probability_rounds_to_int(has
 
 
 async def test_public_forecast_daily_rural_style_entries_have_temps(hass):
-    """Rural daily entries (temps + description via _scan_forecasts fallback,
-    no observations at all) still produce a full forecast entry.
-    """
+    """Rural daily entries, populated via the _scan_forecasts fallback with no observations, still produce a full forecast entry."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
         daily_entries=[
-            DailyEntry(condition="cloudy", temp_high=17.0, temp_low=5.0, datetime="2024-06-15", description="Regional cloudy")
+            DailyEntry(
+                condition="cloudy",
+                temp_high=17.0,
+                temp_low=5.0,
+                datetime="2024-06-15",
+                description="Regional cloudy",
+            )
         ]
     )
     entity = MetServiceForecastPublic(coord)
@@ -349,6 +472,7 @@ async def test_public_forecast_daily_rural_style_entries_have_temps(hass):
 
 
 async def test_public_async_forecast_hourly(hass):
+    """async_forecast_hourly returns an empty list when there is no hourly data."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result = await entity.async_forecast_hourly()
@@ -356,6 +480,7 @@ async def test_public_async_forecast_hourly(hass):
 
 
 async def test_public_async_forecast_daily(hass):
+    """async_forecast_daily returns an empty list when there is no daily data."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result = await entity.async_forecast_daily()
@@ -363,12 +488,14 @@ async def test_public_async_forecast_daily(hass):
 
 
 async def test_public_extra_state_attributes_is_none(hass):
+    """extra_state_attributes is None for the public forecast entity."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     assert entity.extra_state_attributes is None
 
 
 async def test_entity_unavailable_when_coordinator_fails(hass):
+    """Available is False when the coordinator's last update failed."""
     coord = _make_coordinator(hass)
     coord.last_update_success = False
     entity = MetServiceForecastPublic(coord)
@@ -379,10 +506,19 @@ async def test_entity_unavailable_when_coordinator_fails(hass):
 # Test: forecast caching — public
 # ---------------------------------------------------------------------------
 
+
 async def test_public_async_forecast_hourly_populates_cache(hass):
+    """async_forecast_hourly populates _forecast_hourly_cache on first call."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        hourly_entries=[HourlyEntry(datetime="2024-06-15T10:00:00+12:00", temperature=20.0, rainfall=0.0, wind_speed=10.0)],
+        hourly_entries=[
+            HourlyEntry(
+                datetime="2024-06-15T10:00:00+12:00",
+                temperature=20.0,
+                rainfall=0.0,
+                wind_speed=10.0,
+            )
+        ],
         hourly_obs=1,
         hourly_skip=0,
     )
@@ -394,9 +530,14 @@ async def test_public_async_forecast_hourly_populates_cache(hass):
 
 
 async def test_public_async_forecast_daily_populates_cache(hass):
+    """async_forecast_daily populates _forecast_daily_cache on first call."""
     coord = _make_coordinator(hass)
     coord.data = MetServicePublicData(
-        daily_entries=[DailyEntry(condition="fine", temp_high=22.0, temp_low=12.0, datetime="2024-06-15")]
+        daily_entries=[
+            DailyEntry(
+                condition="fine", temp_high=22.0, temp_low=12.0, datetime="2024-06-15"
+            )
+        ]
     )
     entity = MetServiceForecastPublic(coord)
     assert entity._forecast_daily_cache is None
@@ -406,6 +547,7 @@ async def test_public_async_forecast_daily_populates_cache(hass):
 
 
 async def test_public_async_forecast_hourly_returns_same_object_on_second_call(hass):
+    """async_forecast_hourly returns the cached object on a second call."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result1 = await entity.async_forecast_hourly()
@@ -414,6 +556,7 @@ async def test_public_async_forecast_hourly_returns_same_object_on_second_call(h
 
 
 async def test_public_async_forecast_daily_returns_same_object_on_second_call(hass):
+    """async_forecast_daily returns the cached object on a second call."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     result1 = await entity.async_forecast_daily()
@@ -422,6 +565,7 @@ async def test_public_async_forecast_daily_returns_same_object_on_second_call(ha
 
 
 async def test_public_handle_coordinator_update_clears_cache(hass):
+    """_handle_coordinator_update clears the hourly and daily forecast caches."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     entity.hass = hass
@@ -434,12 +578,15 @@ async def test_public_handle_coordinator_update_clears_cache(hass):
 
 
 async def test_public_handle_coordinator_update_schedules_listeners(hass):
+    """_handle_coordinator_update schedules forecast listener updates."""
     coord = _make_coordinator(hass)
     entity = MetServiceForecastPublic(coord)
     entity.hass = hass
-    with patch.object(entity, "async_write_ha_state"), \
-         patch.object(entity, "async_update_listeners", new_callable=AsyncMock) as mock_listeners:
+    with (
+        patch.object(entity, "async_write_ha_state"),
+        patch.object(
+            entity, "async_update_listeners", new_callable=AsyncMock
+        ) as mock_listeners,
+    ):
         entity._handle_coordinator_update()
     mock_listeners.assert_called_once_with(None)
-
-


### PR DESCRIPTION
## Summary

- **Fixes #2, #3; delivers the rural-town half of #4** — full details in `release_notes.md`:
  - MetService's `rainFall1/rainFall10` are exceedance probabilities, not amounts; the daily forecast now exposes `precipitation_probability` and no longer fabricates precipitation mm
  - Rural locations (~80 in the picker) now populate daily temps, descriptions, rain probabilities, tomorrow sensors, and today's high/low; never-available observation/breakdown sensors are gated off and stale registry entries cleaned
- **Switch to HA-style calendar versioning** — v1.0.1 → v2026.7.0
- **All ruff debt cleared** (247 findings → 0), repo ruff-formatted, format check enforced in lint workflow
- **New Test workflow** — pytest + 95% coverage gate in CI (was previously local-only)
- New rural (Kumeu) API fixtures; capture script parameterized; test/lint scripts made worktree-safe

## Test plan

- 258 tests pass at 95.11% coverage (206 before)
- Shape-heuristic tests cover towns/rural/day-level-only payloads, capability gating, registry cleanup, exceedance monotonicity on both fixture sets
- `ruff check .` and `ruff format --check .` clean
- CI on this PR exercises the new Test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)