### PR TITLE
Bump test harness pair: homeassistant 2026.8.0 + pytest-homeassistant-custom-component 0.13.354

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 # Test harness — keep this pair matched: each pytest-homeassistant-custom-component
 # release pins one exact Home Assistant version (Dependabot keeps both fresh).
-homeassistant==2026.7.4
-pytest-homeassistant-custom-component==0.13.348
+homeassistant==2026.8.0
+pytest-homeassistant-custom-component==0.13.354


### PR DESCRIPTION
Supersedes #22.

## Why #22 could not be merged

Dependabot's `test-harness` group opened #22 bumping only `pytest-homeassistant-custom-component` 0.13.348 → 0.13.351. That release pins `homeassistant==2026.8.0b3`, and Dependabot does not propose prereleases for the paired `homeassistant` pin — so the group moved one half of the pair and Pytest failed at install:

```
ERROR: Cannot install -r requirements-test.txt (line 4), homeassistant==2026.7.4 and homeassistant>=2024.02.0
       because these package versions have conflicting dependencies.
    pytest-homeassistant-custom-component 0.13.351 depends on homeassistant==2026.8.0b3
```

Home Assistant 2026.8.0 left beta on 2026-08-05, about 90 minutes after #22 was opened. phacc 0.13.354 pins `homeassistant==2026.8.0` exactly, so the pair is resolvable again.

## Change

```diff
-homeassistant==2026.7.4
-pytest-homeassistant-custom-component==0.13.348
+homeassistant==2026.8.0
+pytest-homeassistant-custom-component==0.13.354
```

Pinned to 2026.8.0 rather than the newer 2026.8.1: no phacc release pins 2026.8.1 yet, and the pair has to stay matched. Dependabot will pick that up in 0.13.355+.

## Verification

Run locally on CPython 3.14.7 to match the `Test` workflow's 3.14 (HA 2026.8.0 requires >=3.14.2):

- Dependencies install cleanly — the resolution conflict that broke #22 is gone
- 636 tests pass
- Coverage 97.15%, against the 95% gate in `pyproject.toml`
- `ruff check` clean; `ruff format --check` clean across 29 files

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTFacKHN9iyuSJL6E8WPh2)_