### PR TITLE
Add Condition today sensor exposing raw MetService tokens (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Earlier versions of this integration included an option to use the MetService mo
 | Rain last hour | mm recorded at the station over the trailing hour — rises and falls with the rain, 0 when dry (not a daily total) |
 | UV index | Enum: `low` / `moderate` / `high` / `very_high` / `extreme`; advice + protection window as attributes |
 | Weather description | Plain-English forecast text |
+| Condition today | MetService's raw condition token verbatim (`few-showers`, `fine-night`, …) for custom cards that render MetService-accurate icons; `daily_conditions` attribute carries the raw token per 7-day forecast day, keyed by date (not recorded in the database) |
 
 **Sub-day forecast**
 

--- a/custom_components/metservice_weather/icons.json
+++ b/custom_components/metservice_weather/icons.json
@@ -155,6 +155,9 @@
       "temperature_today_low": {
         "default": "mdi:thermometer"
       },
+      "condition_today": {
+        "default": "mdi:weather-partly-cloudy"
+      },
       "tomorrow_condition": {
         "default": "mdi:weather-partly-cloudy"
       },

--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -304,13 +304,16 @@ class WeatherSensor(MetServiceEntity, SensorEntity):
     """Implementing the MetService sensor."""
 
     _attr_attribution = CONF_ATTRIBUTION
-    # Bulky machine-payload attributes on the opt-in carrier sensors
-    # (tide_direction, warning_details) stay live in the state machine but
-    # are never written to the recorder. Matching is by attribute name
-    # across the whole class, so these names must stay unique to their
-    # carriers — in particular the deprecated weather_warnings sensor's
-    # "warnings" attribute must keep recording, hence "active_warnings".
-    _unrecorded_attributes = frozenset({"tide_table", "active_warnings"})
+    # Bulky machine-payload attributes on the carrier sensors
+    # (tide_direction, warning_details, condition_today) stay live in the
+    # state machine but are never written to the recorder. Matching is by
+    # attribute name across the whole class, so these names must stay
+    # unique to their carriers — in particular the deprecated
+    # weather_warnings sensor's "warnings" attribute must keep recording,
+    # hence "active_warnings".
+    _unrecorded_attributes = frozenset(
+        {"tide_table", "active_warnings", "daily_conditions"}
+    )
     entity_description: WeatherSensorEntityDescription
 
     def __init__(

--- a/custom_components/metservice_weather/strings.json
+++ b/custom_components/metservice_weather/strings.json
@@ -343,6 +343,9 @@
       "temperature_today_low": {
         "name": "Low temperature today"
       },
+      "condition_today": {
+        "name": "Condition today"
+      },
       "tomorrow_condition": {
         "name": "Condition tomorrow"
       },

--- a/custom_components/metservice_weather/translations/en.json
+++ b/custom_components/metservice_weather/translations/en.json
@@ -343,6 +343,9 @@
       "temperature_today_low": {
         "name": "Low temperature today"
       },
+      "condition_today": {
+        "name": "Condition today"
+      },
       "tomorrow_condition": {
         "name": "Condition tomorrow"
       },

--- a/custom_components/metservice_weather/weather_current_conditions_sensors.py
+++ b/custom_components/metservice_weather/weather_current_conditions_sensors.py
@@ -1050,6 +1050,32 @@ current_condition_sensor_descriptions_public = [
         ),
         value_fn=lambda data, _: _safe_float(data.temp_today_low),
     ),
+    WeatherSensorEntityDescription(
+        key="condition_today",
+        translation_key="condition_today",
+        name="Condition today",
+        # State is MetService's raw condition token verbatim (few-showers,
+        # fine, partly-cloudy-night, ...), NOT the HA-mapped value the
+        # weather entity reports — custom cards use it to render the icon
+        # MetService actually draws. Tokens keep their -night variants, so
+        # the state flips at dawn/dusk by design. daily_conditions carries
+        # the same pre-mapping token for each 7-day forecast day; it is
+        # date-keyed because entry 0 can lag the wall-clock date by up to
+        # one poll after midnight — consumers must match on date, never on
+        # index. The list is excluded from the recorder via
+        # WeatherSensor._unrecorded_attributes.
+        value_fn=lambda data, _: cast(str, data.condition) if data.condition else None,
+        attr_fn=lambda data: {
+            "daily_conditions": [
+                {
+                    "date": entry.datetime[:10] if entry.datetime else None,
+                    "condition": entry.condition,
+                }
+                for entry in data.daily_entries
+                if entry.condition
+            ]
+        },
+    ),
     # --- Tomorrow's forecast (injected from 7-day data) ---
     WeatherSensorEntityDescription(
         key="tomorrow_condition",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -37,7 +37,10 @@ from custom_components.metservice_weather.weather_current_conditions_sensors imp
     _UNKNOWN_MOON_PHASE_LOGGED,
     current_condition_sensor_descriptions_public,
 )
-from custom_components.metservice_weather.coordinator_types import MetServicePublicData
+from custom_components.metservice_weather.coordinator_types import (
+    DailyEntry,
+    MetServicePublicData,
+)
 
 
 def _desc(key: str) -> WeatherSensorEntityDescription:
@@ -1300,15 +1303,62 @@ def test_warning_details_zero_when_clear():
 
 
 def test_carrier_payload_attributes_are_recorder_exempt():
-    """The two machine-payload attribute names are excluded from the recorder.
+    """The machine-payload attribute names are excluded from the recorder.
 
     Matching is by attribute name class-wide, so the set must never contain
     "warnings" — that would silently stop recording the deprecated
     weather_warnings sensor's frozen attribute.
     """
     assert WeatherSensor._unrecorded_attributes == frozenset(
-        {"tide_table", "active_warnings"}
+        {"tide_table", "active_warnings", "daily_conditions"}
     )
+
+
+# ---------------------------------------------------------------------------
+# Test: condition_today raw-token sensor (issue #33)
+# ---------------------------------------------------------------------------
+
+
+def test_condition_today_state_is_raw_token_verbatim():
+    """State is MetService's un-mapped token, -night variants included."""
+    desc = _desc("condition_today")
+    data = MetServicePublicData(condition="few-showers")
+    assert desc.value_fn(data, "metric") == "few-showers"
+    data = MetServicePublicData(condition="partly-cloudy-night")
+    assert desc.value_fn(data, "metric") == "partly-cloudy-night"
+
+
+def test_condition_today_none_without_condition():
+    """No condition in the payload: state None, stable empty-list attribute."""
+    desc = _desc("condition_today")
+    data = MetServicePublicData()
+    assert desc.value_fn(data, "metric") is None
+    assert desc.attr_fn(data) == {"daily_conditions": []}
+
+
+def test_condition_today_daily_conditions_attribute_is_date_keyed_and_raw():
+    """daily_conditions carries the pre-mapping token per day, keyed by date.
+
+    Entries without a condition are dropped; an entry without a datetime
+    keeps its token with date None rather than being silently lost.
+    """
+    desc = _desc("condition_today")
+    data = MetServicePublicData(
+        condition="fine",
+        daily_entries=[
+            DailyEntry(datetime="2026-09-01T00:00:00+12:00", condition="fine"),
+            DailyEntry(datetime="2026-09-02T00:00:00+12:00", condition="few-showers"),
+            DailyEntry(datetime="2026-09-03T00:00:00+12:00", condition=None),
+            DailyEntry(datetime=None, condition="frost"),
+        ],
+    )
+    assert desc.attr_fn(data) == {
+        "daily_conditions": [
+            {"date": "2026-09-01", "condition": "fine"},
+            {"date": "2026-09-02", "condition": "few-showers"},
+            {"date": None, "condition": "frost"},
+        ]
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #33.

Adds `sensor.<location>_condition_today`:

- **State** = MetService's raw condition token verbatim (`few-showers`, `fine`, `partly-cloudy-night`, ...) — no mapping to HA's fixed condition set, `-night` variants preserved, unknown tokens pass through.
- **`daily_conditions` attribute** = the pre-mapping token per 7-day forecast day, keyed by date (consumers match on `date`, not index — entry 0 can lag wall-clock date by up to one poll after midnight). Excluded from the recorder via `_unrecorded_attributes`, same as `tide_table`/`active_warnings`.
- Weather entity untouched — its `condition`/forecasts stay HA-mapped so stock cards keep working.

Design validated against core precedent (Buienradar/AccuWeather/Environment Canada raw-token sensors; service-action alternative rejected — no reactive signal for cards). Includes the strings/translations/icons triple, README row, and tests (639 passing, 97% coverage; the locked `_unrecorded_attributes` test extended per its own warning).

Already shipped as prerelease v2026.9.0a1 from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)