### PR TITLE
Reclaim confirm text: state both actions explicitly

### DIFF
--- a/custom_components/metservice_weather/strings.json
+++ b/custom_components/metservice_weather/strings.json
@@ -436,7 +436,7 @@
         "step": {
           "confirm": {
             "title": "Rename {count} entity ID(s)?",
-            "description": "A deprecated sensor held the canonical ID, so these landed on suffixed ones. The deprecated sensors are gone and nothing references the current IDs:\n\n{renames}\n\nHistory and settings move with the rename. Prefer the current IDs? **Ignore** this repair instead."
+            "description": "A deprecated sensor held the canonical ID, so these landed on suffixed ones. The deprecated sensors are gone and nothing references the current IDs:\n\n{renames}\n\nHistory and settings move with the rename.\n\nSelect **Submit** to rename, or **Ignore** this repair to leave things as they are."
           }
         }
       }

--- a/custom_components/metservice_weather/translations/en.json
+++ b/custom_components/metservice_weather/translations/en.json
@@ -436,7 +436,7 @@
         "step": {
           "confirm": {
             "title": "Rename {count} entity ID(s)?",
-            "description": "A deprecated sensor held the canonical ID, so these landed on suffixed ones. The deprecated sensors are gone and nothing references the current IDs:\n\n{renames}\n\nHistory and settings move with the rename. Prefer the current IDs? **Ignore** this repair instead."
+            "description": "A deprecated sensor held the canonical ID, so these landed on suffixed ones. The deprecated sensors are gone and nothing references the current IDs:\n\n{renames}\n\nHistory and settings move with the rename.\n\nSelect **Submit** to rename, or **Ignore** this repair to leave things as they are."
           }
         }
       }


### PR DESCRIPTION
The confirm step now ends by telling the user exactly what to do: **Submit** to rename, or **Ignore** the repair to leave things as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)