### PR TITLE
Replace two deprecated device registry calls

### DIFF
--- a/custom_components/metservice_weather/__init__.py
+++ b/custom_components/metservice_weather/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from .coordinator import WeatherUpdateCoordinator, WeatherUpdateCoordinatorConfig
+from .entity import async_register_location_device
 from .const import (
     DOMAIN,
     LOCATIONS,
@@ -104,6 +105,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: MetServiceConfigEntry):
     await weathercoordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = weathercoordinator
+
+    # Registered before the platforms are forwarded: marine entities link
+    # to this device with via_device_id, which needs the parent's registry
+    # id to already exist (see entity.async_register_location_device).
+    weathercoordinator.location_device_id = async_register_location_device(
+        hass, entry, weathercoordinator
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/metservice_weather/coordinator.py
+++ b/custom_components/metservice_weather/coordinator.py
@@ -71,6 +71,11 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator[MetServicePublicData]):
         self._unit_system_api = config.unit_system_api
         self._base_url = "https://www.metservice.com"
         self.unit_system = config.unit_system
+        # Device registry id of the town/rural location device, set by
+        # entity.async_register_location_device during entry setup. The
+        # marine device needs it for via_device_id (an id, not an
+        # identifier tuple); None until that registration has run.
+        self.location_device_id: str | None = None
         self._session = async_get_clientsession(hass)
         self.units_of_measurement = {
             TEMPUNIT: UnitOfTemperature.CELSIUS,

--- a/custom_components/metservice_weather/deprecation.py
+++ b/custom_components/metservice_weather/deprecation.py
@@ -787,7 +787,13 @@ async def async_check_marine_device_move(
             return
 
         dev_reg = dr.async_get(hass)
-        device = dev_reg.async_get_device(identifiers={(DOMAIN, coordinator.location)})
+        # Scoped to this entry: identifiers are only unique within a config
+        # entry, so the unscoped async_get_device is deprecated (removed in
+        # HA 2027.8) and could resolve to another entry's location device
+        # on a multi-location install.
+        device = dev_reg.async_get_device_by_identifier(
+            (DOMAIN, coordinator.location), entry.entry_id
+        )
         if device is None:
             ir.async_delete_issue(hass, DOMAIN, issue_id)
             return

--- a/custom_components/metservice_weather/entity.py
+++ b/custom_components/metservice_weather/entity.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOCATIONS, MANUFACTURER
 from .coordinator import WeatherUpdateCoordinator
+
+# Shared by the location device's two write paths: the explicit
+# async_register_location_device below and MetServiceEntity's own DeviceInfo.
+_MODEL = "MetService Public API"
+_CONFIGURATION_URL = "https://www.metservice.com"
 
 # MetService marine region slug -> official display label, captured from
 # https://www.metservice.com/publicData/webdata/marine's
@@ -82,6 +90,34 @@ def _location_device_name(coordinator: WeatherUpdateCoordinator) -> str:
     return coordinator.location_name
 
 
+@callback
+def async_register_location_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: WeatherUpdateCoordinator,
+) -> str:
+    """Register the town/rural location device and return its registry id.
+
+    The marine device links to this one with ``via_device_id``, which takes
+    a device registry id rather than the ``(domain, identifier)`` tuple the
+    deprecated ``via_device`` took. That means the parent device has to
+    already exist when a marine entity builds its DeviceInfo — and since
+    the platforms are forwarded concurrently, no platform can be relied on
+    to have created it first. So it is registered once here, from
+    ``async_setup_entry`` before the forward, and the id is cached on the
+    coordinator as ``location_device_id``.
+    """
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, coordinator.location)},
+        name=_location_device_name(coordinator),
+        manufacturer=MANUFACTURER,
+        model=_MODEL,
+        configuration_url=_CONFIGURATION_URL,
+    )
+    return device.id
+
+
 class MetServiceEntity(CoordinatorEntity[WeatherUpdateCoordinator]):
     """Base class providing shared DeviceInfo for all MetService entities."""
 
@@ -97,26 +133,32 @@ class MetServiceEntity(CoordinatorEntity[WeatherUpdateCoordinator]):
         every entity used before marine support existed; "marine" is a
         separate device describing the selected marine region (tides,
         boating, surf — these describe the region, not the town) and is
-        linked under the location device via via_device.
+        linked under the location device via via_device_id, whose value
+        async_register_location_device caches on the coordinator.
         """
         super().__init__(coordinator)
         location_label = _location_device_name(coordinator)
         if device == "marine":
-            self._attr_device_info = DeviceInfo(
+            device_info = DeviceInfo(
                 identifiers={(DOMAIN, f"{coordinator.location}_marine")},
                 name=_marine_device_name(
                     coordinator.marine_region_slug, location_label
                 ),
                 manufacturer=MANUFACTURER,
-                model="MetService Public API",
-                configuration_url="https://www.metservice.com",
-                via_device=(DOMAIN, coordinator.location),
+                model=_MODEL,
+                configuration_url=_CONFIGURATION_URL,
             )
+            # Left out entirely rather than set to None when the parent
+            # hasn't been registered: an explicit via_device_id=None is a
+            # write meaning "no parent", which would clear an existing link.
+            if coordinator.location_device_id is not None:
+                device_info["via_device_id"] = coordinator.location_device_id
+            self._attr_device_info = device_info
         else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, coordinator.location)},
                 name=location_label,
                 manufacturer=MANUFACTURER,
-                model="MetService Public API",
-                configuration_url="https://www.metservice.com",
+                model=_MODEL,
+                configuration_url=_CONFIGURATION_URL,
             )

--- a/custom_components/metservice_weather/manifest.json
+++ b/custom_components/metservice_weather/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/nagelm/metservice-weather/issues",
   "quality_scale": "gold",
   "requirements": [],
-  "version": "2026.9.0"
+  "version": "2026.9.1"
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,14 @@
+## v2026.9.1
+
+### Fixed
+
+Home Assistant 2026.9 logs two deprecation warnings for this integration at every startup — both for calls that stop working in Home Assistant 2027.8.0. Both are gone:
+
+- The marine device is now linked to its parent location device by device registry id (`via_device_id`) rather than the deprecated `(domain, identifier)` tuple. The location device is registered explicitly during setup so the id exists before any marine entity is built. Nothing changes on screen: the device tree, entity IDs, and history are all unaffected.
+- The marine-device-move repair check now looks the location device up scoped to its own config entry. This also closes a latent mismatch on installs with two entries pointing at the same MetService location, where the old unscoped lookup could resolve to the other entry's device.
+
+---
+
 ## v2026.9.0
 
 ### The 14 deprecated sensors are removed

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -135,13 +135,15 @@ async def test_location_device_is_the_default(hass):
     assert info["identifiers"] == {(DOMAIN, coord.location)}
     assert info["name"] == "Napier"
     assert info.get("via_device") is None
+    assert info.get("via_device_id") is None
 
 
 async def test_marine_device_has_distinct_identifier_and_via_device(hass):
     """device="marine" builds a separate, linked device.
 
-    Linked under the location device via via_device, with a name that
-    reflects the marine region.
+    Linked under the location device via via_device_id — the registry id
+    cached on the coordinator, never the deprecated via_device tuple —
+    with a name that reflects the marine region.
     """
     coord = _make_coordinator(
         hass,
@@ -150,12 +152,34 @@ async def test_marine_device_has_distinct_identifier_and_via_device(hass):
             "kapiti-wellington/tides/locations/wellington"
         ),
     )
+    coord.location_device_id = "parent-device-id"
     ent = MetServiceEntity(coord, device="marine")
     info = ent.device_info
     assert info["identifiers"] == {(DOMAIN, f"{coord.location}_marine")}
     assert info["identifiers"] != {(DOMAIN, coord.location)}
-    assert info["via_device"] == (DOMAIN, coord.location)
+    assert info["via_device_id"] == "parent-device-id"
+    assert "via_device" not in info
     assert info["name"] == "Kapiti and Wellington"
+
+
+async def test_marine_device_omits_via_device_id_when_parent_unregistered(hass):
+    """No cached parent id means the key is omitted, not written as None.
+
+    An explicit via_device_id=None is a write meaning "no parent", which
+    would clear an already-recorded link; omitting the key leaves whatever
+    the registry already holds alone.
+    """
+    coord = _make_coordinator(
+        hass,
+        tide_url=(
+            "https://www.metservice.com/publicData/webdata/marine/regions/"
+            "kapiti-wellington/tides/locations/wellington"
+        ),
+    )
+    assert coord.location_device_id is None
+    info = MetServiceEntity(coord, device="marine").device_info
+    assert "via_device_id" not in info
+    assert "via_device" not in info
 
 
 async def test_marine_device_falls_back_to_location_name_when_no_marine_url(hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -55,6 +56,51 @@ async def test_setup_and_unload_public(hass):
 
     assert unload_result is True
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_links_marine_device_under_location_device(hass):
+    """Setup registers the location device and links the marine one to it by id.
+
+    via_device_id takes a device registry id, so the parent has to be
+    registered before the platforms build any marine DeviceInfo. This
+    asserts the resulting registry state end to end: two devices, the
+    marine one pointing at the location one's real id.
+    """
+    marine_base = "https://www.metservice.com/publicData/webdata/marine/regions"
+    entry = _make_entry(
+        {
+            **_PUBLIC_ENTRY_DATA,
+            "marine_region": "marine/regions/kapiti-wellington",
+            "tide_url": f"{marine_base}/kapiti-wellington/tides/locations/wellington",
+            "boating_url": f"{marine_base}/kapiti-wellington/boating/locations/wellington",
+            "surf_url": f"{marine_base}/kapiti-wellington/surf/locations/lyall-bay",
+        }
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.metservice_weather.WeatherUpdateCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data
+    dev_reg = dr.async_get(hass)
+
+    location_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, coordinator.location), entry.entry_id
+    )
+    assert location_device is not None
+    assert location_device.id == coordinator.location_device_id
+    assert location_device.name == "Napier"
+
+    marine_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{coordinator.location}_marine"), entry.entry_id
+    )
+    assert marine_device is not None
+    assert marine_device.id != location_device.id
+    assert marine_device.via_device_id == location_device.id
 
 
 async def test_unload_returns_true_when_platforms_unload(hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,9 @@ from custom_components.metservice_weather.coordinator import (
     WeatherUpdateCoordinator,
     WeatherUpdateCoordinatorConfig,
 )
+from custom_components.metservice_weather.entity import (
+    async_register_location_device,
+)
 from custom_components.metservice_weather.sensor import WeatherSensor
 from custom_components.metservice_weather.weather_current_conditions_sensors import (
     WeatherSensorEntityDescription,
@@ -580,7 +583,7 @@ async def test_marine_skip_setup_creates_no_marine_device_entities(hass):
 async def test_marine_enabled_setup_groups_marine_sensors_under_their_own_device(hass):
     """Marine sensors land on a device distinct from the location device.
 
-    Linked to it via via_device, while non-marine sensors stay on the
+    Linked to it via via_device_id, while non-marine sensors stay on the
     location device as before.
     """
     from custom_components.metservice_weather.sensor import async_setup_entry
@@ -625,7 +628,9 @@ async def test_marine_enabled_setup_groups_marine_sensors_under_their_own_device
     )
     coord = WeatherUpdateCoordinator(hass, config)
     coord.data = MetServicePublicData()
+    entry.add_to_hass(hass)
     entry.runtime_data = coord
+    coord.location_device_id = async_register_location_device(hass, entry, coord)
 
     added = []
 
@@ -647,13 +652,15 @@ async def test_marine_enabled_setup_groups_marine_sensors_under_their_own_device
         info = sensor.device_info
         assert info["identifiers"] == {marine_identifier}
         assert info["identifiers"] != {location_identifier}
-        assert info["via_device"] == location_identifier
+        assert info["via_device_id"] == coord.location_device_id
+        assert "via_device" not in info
         assert info["name"] == "Kapiti and Wellington"
 
     for sensor in location_sensors:
         info = sensor.device_info
         assert info["identifiers"] == {location_identifier}
         assert info.get("via_device") is None
+        assert info.get("via_device_id") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Home Assistant 2026.9 logs a deprecation warning for each of two device registry calls in this integration; both stop working in HA 2027.8.0.

## `via_device` → `via_device_id`

`via_device_id` takes a device registry **id**, not an `(domain, identifier)` tuple, so the parent location device has to already exist when a marine entity builds its `DeviceInfo`. Platforms are forwarded concurrently, so no platform can be relied on to have created it first — `async_setup_entry` now registers it explicitly (`entity.async_register_location_device`) before the forward and caches the id on the coordinator as `location_device_id`.

The key is omitted rather than set to `None` when that id is missing: an explicit `via_device_id=None` is a write meaning "no parent", which would clear an existing link.

## `async_get_device` → `async_get_device_by_identifier`

Identifiers are only unique within a config entry, so the marine-device-move repair check now scopes its lookup to the entry. This also closes a latent mismatch where two entries on the same MetService location could resolve to each other's device.

## Verification

- 616 tests pass, 97.07% coverage (`entity.py` at 100%), ruff clean.
- New end-to-end test in `tests/test_init.py` sets an entry up with marine URLs and asserts the real device registry links the marine device to the location device by id.
- Existing `via_device` assertions in `test_entity.py` / `test_sensor.py` updated, plus a new test that the key is omitted (not `None`) when the parent is unregistered.

Nothing changes on screen: device tree, entity IDs, and history are unaffected.

Version bumped to `2026.9.1` with a release-notes section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
